### PR TITLE
Make metadata.deploy fail instead of never resolving on incorrect input

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -296,6 +296,8 @@ Metadata.prototype.deploy = function(zipInput, options, callback) {
     zipInput.resume();
   } else if (zipInput instanceof Buffer) {
     deferred.resolve(zipInput);
+  } else {
+    throw "Unexpected zipInput type";
   }
 
   var self = this;


### PR DESCRIPTION
It took me a long time to figure out what I was doing wrong, since there was no error given to me, it just seemed like the deployment never finished, because the promise was never resolved or rejected.
