### PR TITLE
Fixes #8 - Assume $in for list with no operator supplied

### DIFF
--- a/lib/soql-builder.js
+++ b/lib/soql-builder.js
@@ -120,7 +120,11 @@ var opMap = {
 /** @private **/
 function createFieldExpression(field, value) {
   var op = "$eq";
-  if (_.isObject(value)) {
+
+  // Assume the `$in` operator if value is an array and none was supplied.
+  if (_.isArray(value)) { op = "$in"; }
+  // Otherwise, if an object was passed then process the supplied ops.
+  else if (_.isObject(value)) {
     var _value;
     for (var k in value) {
       if (k[0] === "$") {


### PR DESCRIPTION
This is a quick fix for issue #8. If `.where()` is called with list as a value in the options key/value pair, then assume the `$in` operator instead of generating a malformed SOQL query. 
