### PR TITLE
Misspelling of receivable

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -22,10 +22,10 @@ var RecordStream = module.exports = function() {
   this.receivable = false;
   this.on('error', function() {
     this.sendable = false;
-    this.recievable = false;
+    this.receivable = false;
   });
   this.on('end', function() {
-    this.recievable = false;
+    this.receivable = false;
   });
 };
 


### PR DESCRIPTION
Saw this when debugging the query 'end' event.  One property was called receivable (correct spelling), and the other was recievable (incorrect spelling).  One was set to 'true' and the other to 'false'.  I figured that it had to be causing some problem somewhere, and should probably be consistent.
