### PR TITLE
Reuse `Connection` object from `browser.init`

### DIFF
--- a/lib/browser/client.js
+++ b/lib/browser/client.js
@@ -105,7 +105,13 @@ Client.prototype.login = function(options, callback) {
 
 Client.prototype._prompt = function(options, callback) {
   var self = this;
-  var oauth2 = new OAuth2(options);
+  var oauth2;
+  if (_.isObject(self.connection) && _.isObject(self.connection.oauth2)) {
+  	oauth2 = self.connection.oauth2;
+  } else {
+  	var oauthOptions = _.isObject(options.oauth2) ? options.oauth2 : options;
+  	oauth2 = new OAuth2(oauthOptions);
+  }
   var rand = Math.random().toString(36).substring(2);
   var state = [ this._prefix, "popup", rand ].join('.');
   localStorage.setItem("jsforce_state", state);


### PR DESCRIPTION
See below for code.

When I call the `browser.login` method, the `Connection` object created in by the `init` method isn't re-used. Because of this, it passes the `config` created in `init` to `new OAuth2`. In the `browser.init` method, this same object is passed to `new Connection`. The config objects for these two classes are not the same shape, so we shouldn't do this. This incompatibility broke my `login` call.

Thoughts? (Note: I didn't write tests or anything for this, but this patch works for me.)

```
     jsforce.browser.init({
        oauth2: {
            loginUrl: loginUrl,
            clientId: clientId,
            clientSecret: clientSecret,
            redirectUri: redirectUri
        },
        accessToken: accessToken,
        sessionId: sessionId,
        refreshToken: refreshToken,
        proxyUrl: proxyUrl
    });
   // Later
   jsforce.browser.login()
```
