### PR TITLE
Return Metadata#describe() result to callback function

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -36,8 +36,8 @@ var Metadata = module.exports = function(conn) {
 };
 
 
-/** 
- * Polling interval in milliseconds 
+/**
+ * Polling interval in milliseconds
  * @type {Number}
  */
 Metadata.prototype.pollInterval = 1000;
@@ -53,7 +53,7 @@ Metadata.prototype.pollTimeout = 10000;
  * Call Metadata API SOAP endpoint
  *
  * @private
- */ 
+ */
 Metadata.prototype._invoke = function(method, message, callback) {
   var soapEndpoint = new SOAP({
     sessionId: this._conn.accessToken,
@@ -62,7 +62,7 @@ Metadata.prototype._invoke = function(method, message, callback) {
   }, this._conn._transport);
   return soapEndpoint.invoke(method, message).then(function(res) {
     return res.result;
-  }).thenCall(callback); 
+  }).thenCall(callback);
 };
 
 /**
@@ -307,12 +307,12 @@ Metadata.prototype.checkStatus = function(ids, callback) {
  * @prop {String} metadataObjects.xmlName - The name of the root element in the metadata file for this component
  * @prop {String} organizationNamespace - The namespace of the organization
  * @prop {Boolean} partialSaveAllowed - Indicates whether rollbackOnError is allowed or not
- * @prop {Boolean} testRequired - Indicates whether tests are required or not 
+ * @prop {Boolean} testRequired - Indicates whether tests are required or not
  */
 
 /**
  * Retrieves the metadata which describes your organization, including Apex classes and triggers,
- * custom objects, custom fields on standard objects, tab sets that define an app, 
+ * custom objects, custom fields on standard objects, tab sets that define an app,
  * and many other components.
  *
  * @param {String} [version] - The API version for which you want metadata; for example, 29.0
@@ -337,7 +337,7 @@ Metadata.prototype.describe = function(version, callback) {
     res.partialSaveAllowed = res.partialSaveAllowed === 'true';
     res.testRequired = res.testRequired === 'true';
     return res;
-  });
+  }).thenCall(callback);
 };
 
 /**
@@ -377,7 +377,7 @@ Metadata.prototype.list = function(queries, version, callback) {
   }
   if (!_.isArray(queries)) {
     queries = [ queries ];
-  } 
+  }
   return this._invoke("listMetadata", { queries: queries, asOfVersion: version }, callback);
 };
 
@@ -399,7 +399,7 @@ Metadata.prototype.retrieve = function(request, callback) {
 
 /**
  * Checks the status of declarative metadata call retrieve() and returns the zip file contents
- * 
+ *
  * @param {String} id - Async process id returned from previous retrieve request
  * @param {Callback.<Metadata~RetrieveResult>} [callback] - Callback function
  * @returns {Promise.<Metadata~RetrieveResult>}
@@ -470,7 +470,7 @@ Metadata.prototype.checkDeployStatus = function(id, includeDetails, callback) {
     callback = includeDetails;
     includeDetails = false;
   }
-  return this._invoke("checkDeployStatus", { 
+  return this._invoke("checkDeployStatus", {
     asyncProcessId: id,
     includeDetails : includeDetails
   }).then(function(res) {
@@ -708,7 +708,7 @@ RetrieveResultLocator.prototype.stream = function() {
  * @class Metadata~DeployResultLocator
  * @extends Metadata~AsyncResultLocator
  * @param {Metadata} meta - Metadata API object
- * @param {Promise.<Metadata~AsyncResult>} result - Promise object for async result of deploy() call 
+ * @param {Promise.<Metadata~AsyncResult>} result - Promise object for async result of deploy() call
  */
 var DeployResultLocator = function(meta, result) {
   DeployResultLocator.super_.call(this, meta, result);


### PR DESCRIPTION
Fixes issue with Metadata `describe` method not sending results to the callback function. Resolves #47
