### PR TITLE
Fix test which never returns on Node.js ver 0.10.30

### DIFF
--- a/test/query.test.js
+++ b/test/query.test.js
@@ -157,7 +157,7 @@ describe("query", function() {
           setTimeout(function() {
             outStream.sendable = true;
             outStream.emit('drain');
-          }, 1000 * Math.random());
+          }, Math.floor(1000 * Math.random()));
         }
         return outStream.sendable;
       };


### PR DESCRIPTION
A test "query big tables by piping randomly-waiting output record stream object" in `query.test.js` is not returning to callback when using node 0.10.30 (latest; currently).
