### PR TITLE
SObject#create() returns error when omitting callback

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -563,6 +563,7 @@ Connection.prototype.create = function(type, records, options, callback) {
     callback = options;
     options = {};
   }
+  options = options || {};
   var self = this;
   var isArray = _.isArray(records);
   records = isArray ? records : [ records ];
@@ -616,6 +617,7 @@ Connection.prototype.update = function(type, records, options, callback) {
     callback = options;
     options = {};
   }
+  options = options || {};
   var self = this;
   var isArray = _.isArray(records);
   records = isArray ? records : [ records ];
@@ -678,6 +680,7 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
     callback = options;
     options = {};
   }
+  options = options || {};
   var self = this;
   var isArray = _.isArray(records);
   records = isArray ? records : [ records ];
@@ -750,6 +753,7 @@ Connection.prototype.destroy = function(type, ids, options, callback) {
     callback = options;
     options = {};
   }
+  options = options || {};
   var self = this;
   var isArray = _.isArray(ids);
   ids = isArray ? ids : [ ids ];


### PR DESCRIPTION
Raises following error:

```
TypeError: Cannot read property 'headers' of undefined
```
