### PR TITLE
Add wait for node-phantom ph initialization

### DIFF
--- a/test/helper/node/webauth.js
+++ b/test/helper/node/webauth.js
@@ -9,7 +9,9 @@ module.exports = function(url, username, password, callback) {
     },
     function(_ph, cb) {
       ph = _ph;
-      ph.createPage(cb);
+      setTimeout(function() {
+        ph.createPage(cb);
+      }, 100);
     },
     function(_page, cb) {
       page = _page;


### PR DESCRIPTION
This is to avoid not-returning issue when `createPage()` is called in the latest node-phantom.
