### PR TITLE
In firefox jsforce returns invalid response

### DIFF
--- a/lib/browser/request.js
+++ b/lib/browser/request.js
@@ -8,6 +8,7 @@ module.exports = function(params, callback) {
       xhr.setRequestHeader(header, params.headers[header]);
     }
   }
+  xhr.setRequestHeader("Accept", "*/*");
   var response;
   var str = new stream.Duplex();
   str._read = function(size) {
@@ -18,7 +19,7 @@ module.exports = function(params, callback) {
   var bufs = [];
   var sent = false;
   str._write = function(chunk, encoding, callback) {
-    bufs.push(chunk.toString(encoding === "buffer" ? "binary" : encoding));
+    bufs.push(chunk.toString(encoding));
     callback();
   };
   str.on('finish', function() {


### PR DESCRIPTION
There is no `Accept` header sent to the request, so API returns XML instead of JSON.
