### PR TITLE
Add limitinfo in connection obj to keep latest API usage

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -202,6 +202,8 @@ Connection.prototype.initialize = function(options) {
     this.userInfo = options.userInfo;
   }
 
+  this.limitInfo = {};
+
   this.sobjects = {};
   this.cache.clear();
   this.cache.get('describeGlobal').on('value', _.bind(function(res) {
@@ -310,6 +312,20 @@ Connection.prototype._request = function(params, callback, options) {
     logger.debug("<response> status=" + response.statusCode + ", url=" + params.url);
 
     self.emit('response', response.statusCode, response.body, response);
+
+    // log api usage and its quota
+    if (response.headers && response.headers["sforce-limit-info"]) {
+      var apiUsage = response.headers["sforce-limit-info"].match(/api\-usage=(\d+)\/(\d+)/)
+      if (apiUsage) {
+        self.limitInfo = {
+          apiUsage: {
+            used: parseInt(apiUsage[1], 10),
+            limit: parseInt(apiUsage[2], 10)
+          }
+        };
+      }
+    }
+
     // Refresh token if status code requires authentication
     // when oauth2 info and refresh token is available.
     if (response.statusCode === 401 &&

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -472,6 +472,20 @@ describe("connection", function() {
   });
 
 
+  /**
+   *
+   */
+  describe("get api limit information", function() {
+    it("should get api usage and its limit in the org", function() {
+      var limitInfo = conn.limitInfo;
+      assert.ok(_.isObject(limitInfo.apiUsage));
+      assert.ok(_.isNumber(limitInfo.apiUsage.used));
+      assert.ok(_.isNumber(limitInfo.apiUsage.limit));
+      assert.ok(limitInfo.apiUsage.used > 0);
+      assert.ok(limitInfo.apiUsage.limit > limitInfo.apiUsage.used);
+    });
+  });
+
 /*------------------------------------------------------------------------*/
 if (testUtils.isNodeJS) {
 


### PR DESCRIPTION
Keep API usage information notified from API HTTP response header.
