### PR TITLE
Enable logout for OAuth logged-in session

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,26 +53,20 @@ var Connection = module.exports = function(options) {
 
   this._logger = new Logger(options.logLevel);
 
-  var oauth2 = options.oauth2;
-  if (!oauth2 && options.clientId) { // if oauth2 client config is written in flat (for compatibility)
-    oauth2 = {
-      loginUrl : options.loginUrl,
-      clientId : options.clientId,
-      clientSecret : options.clientSecret,
-      redirectUri : options.redirectUri
-    };
-  }
+  var oauth2 = options.oauth2 || {
+    loginUrl : options.loginUrl,
+    clientId : options.clientId,
+    clientSecret : options.clientSecret,
+    redirectUri : options.redirectUri
+  };
 
+  /**
+   * OAuth2 object
+   * @member {OAuth2} Connection#oauth2
+   */
+  this.oauth2 = oauth2 instanceof OAuth2 ? oauth2 : new OAuth2(oauth2);
 
-  if (oauth2) {
-    /**
-     * OAuth2 object
-     * @member {OAuth2} Connection#oauth2
-     */
-    this.oauth2 = oauth2 instanceof OAuth2 ? oauth2 : new OAuth2(oauth2);
-  }
-
-  this.loginUrl = options.loginUrl || (oauth2 && oauth2.loginUrl) || defaults.loginUrl;
+  this.loginUrl = options.loginUrl || oauth2.loginUrl || defaults.loginUrl;
   this.version = options.version || defaults.version;
   this.maxRequest = options.maxRequest || this.maxRequest || 10;
 
@@ -217,6 +211,7 @@ Connection.prototype.initialize = function(options) {
     this.tooling.initialize();
   }
 
+  this._sessionType = options.sessionId ? "soap" : "oauth2";
   this._initializedAt = Date.now();
 
 };
@@ -950,7 +945,7 @@ Connection.prototype.authorize = function(code, callback) {
  * @returns {Promise.<UserInfo>}
  */
 Connection.prototype.login = function(username, password, callback) {
-  if (this.oauth2) {
+  if (this.oauth2 && this.oauth2.clientId && this.oauth2.clientSecret) {
     return this.loginByOAuth2(username, password, callback);
   } else {
     return this.loginBySoap(username, password, callback);
@@ -1060,12 +1055,50 @@ Connection.prototype.loginBySoap = function(username, password, callback) {
 };
 
 /**
- * Logout the session by using SOAP web service API
+ * Logout the current session
  *
  * @param {Callback.<undefined>} [callback] - Callback function
  * @returns {Promise.<undefined>}
  */
 Connection.prototype.logout = function(callback) {
+  if (this._sessionType === "oauth2") {
+    return this.logoutByOAuth2(callback);
+  } else {
+    return this.logoutBySoap(callback);
+  }
+};
+
+/**
+ * Logout the current session by revoking access token via OAuth2 session revoke
+ *
+ * @param {Callback.<undefined>} [callback] - Callback function
+ * @returns {Promise.<undefined>}
+ */
+Connection.prototype.logoutByOAuth2 = function(callback) {
+  var self = this;
+  var logger = this._logger;
+
+  return this.oauth2.revokeToken(this.accessToken).then(function() {
+    // Destroy the session bound to this connection
+    self.accessToken = null;
+    self.userInfo = null;
+    self.refreshToken = null;
+    self.instanceUrl = null;
+    self.cache.clear();
+
+    // nothing useful returned by logout API, just return
+    return undefined;
+  }).thenCall(callback);
+};
+
+
+/**
+ * Logout the session by using SOAP web service API
+ *
+ * @param {Callback.<undefined>} [callback] - Callback function
+ * @returns {Promise.<undefined>}
+ */
+Connection.prototype.logoutBySoap = function(callback) {
   var self = this;
   var logger = this._logger;
 

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -28,10 +28,12 @@ var OAuth2 = module.exports = function(options) {
     this.loginUrl = options.authzServiceUrl.split('/').slice(0, 3).join('/');
     this.authzServiceUrl = options.authzServiceUrl;
     this.tokenServiceUrl = options.tokenServiceUrl;
+    this.revokeServiceUrl = options.revokeServiceUrl;
   } else {
     this.loginUrl = options.loginUrl || defaults.loginUrl;
     this.authzServiceUrl = this.loginUrl + "/services/oauth2/authorize";
     this.tokenServiceUrl = this.loginUrl + "/services/oauth2/token";
+    this.revokeServiceUrl = this.loginUrl + "/services/oauth2/revoke";
   }
   this.clientId = options.clientId;
   this.clientSecret = options.clientSecret;
@@ -127,6 +129,34 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
   },
 
   /**
+   * OAuth2 Revoke Session Token
+   *
+   * @param {String} accessToken - Access token to revoke
+   * @param {Callback.<undefined>} [callback] - Callback function
+   * @returns {Promise.<undefined>}
+   */
+  revokeToken : function(accessToken, callback) {
+    return this._transport.httpRequest({
+      method : 'POST',
+      url : this.revokeServiceUrl,
+      body: querystring.stringify({ token: accessToken }),
+      headers: {
+        "content-type" : "application/x-www-form-urlencoded"
+      }
+    }).then(function(response) {
+      if (response.statusCode >= 400) {
+        var res = querystring.parse(response.body);
+        if (!res || !res.error) {
+          res = { error: "ERROR_HTTP_"+response.statusCode, error_description: response.body };
+        }
+        var err = new Error(res.error_description);
+        err.name = res.error;
+        throw err;
+      }
+    }).thenCall(callback);
+  },
+
+  /**
    * @private
    */
   _postParams : function(params, callback) {
@@ -138,9 +168,13 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
         "content-type" : "application/x-www-form-urlencoded"
       }
     }).then(function(response) {
-      var res = JSON.parse(response.body);
+      var res;
+      try {
+        res = JSON.parse(response.body);
+      } catch(e) {}
       if (response.statusCode >= 400) {
-        var err = new Error(res.error + ": " + res.error_description);
+        res = res || { error: "ERROR_HTTP_"+response.statusCode, error_description: response.body };
+        var err = new Error(res.error_description);
         err.name = res.error;
         throw err;
       }

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -12,7 +12,9 @@ var nodeRequest = require('request'),
 
 var request;
 if (typeof window === 'undefined') {
-  var defaults = {};
+  var defaults = {
+    followAllRedirects: true
+  };
   if (process.env.HTTP_PROXY) {
     defaults.proxy = process.env.HTTP_PROXY;
   }

--- a/test/connection-session.test.js
+++ b/test/connection-session.test.js
@@ -1,0 +1,227 @@
+/*global describe, it, before */
+var testUtils = require('./helper/test-utils'),
+    assert = testUtils.assert;
+
+var async  = require('async'),
+    _      = require('underscore'),
+    authorize = require('./helper/webauth'),
+    sf     = require('../lib/jsforce'),
+    config = require('./config/salesforce');
+
+/**
+ *
+ */
+describe("connection-session", function() {
+
+  this.timeout(20000); // set timeout to 20 sec.
+
+  /**
+   *
+   */
+  describe("login", function() {
+    it("should login by username and password", function(done) {
+      var conn = new sf.Connection({ logLevel: config.logLevel });
+      conn.login(config.username, config.password, function(err, userInfo) {
+        if (err) { throw err; }
+        assert.ok(_.isString(conn.accessToken));
+        assert.ok(_.isString(userInfo.id));
+        assert.ok(_.isString(userInfo.organizationId));
+        assert.ok(_.isString(userInfo.url));
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("logout", function() {
+
+    describe("soap session", function() {
+      var sessionInfo;
+      it("should logout soap session", function(done) {
+        var conn1 = new sf.Connection({ logLevel: config.logLevel });
+        conn1.loginBySoap(config.username, config.password, function(err) {
+          if (err) { return done(err); }
+          sessionInfo = {
+            sessionId : conn1.accessToken,
+            serverUrl : conn1.instanceUrl
+          };
+          conn1.logout(function(err) {
+            if (err) { throw err; }
+            assert.ok(_.isNull(conn1.accessToken));
+          }.check(done));
+        });
+      });
+
+      describe("then connect with previous session info", function() {
+        it("should raise authentication error", function(done) {
+          var conn2 = new sf.Connection({
+            sessionId: sessionInfo.sessionId,
+            serverUrl: sessionInfo.serverUrl,
+            logLevel: config.logLevel
+          });
+          setTimeout(function() { // wait a moment
+            conn2.query("SELECT Id FROM User", function(err, res) {
+              assert.ok(err && _.isString(err.message));
+            }.check(done));
+          }, 10000);
+        });
+      });
+    });
+
+    describe("oauth2 session", function() {
+      var sessionInfo;
+      it("should logout oauth2 session", function(done) {
+        var conn1 = new sf.Connection({
+          oauth2: {
+            clientId : config.clientId,
+            clientSecret : config.clientSecret,
+            redirectUri : config.redirectUri
+          },
+          logLevel : config.logLevel
+        });
+        conn1.loginByOAuth2(config.username, config.password, function(err) {
+          if (err) { return done(err); }
+          sessionInfo = {
+            accessToken : conn1.accessToken,
+            instanceUrl : conn1.instanceUrl
+          };
+          conn1.logout(function(err) {
+            if (err) { throw err; }
+            assert.ok(_.isNull(conn1.accessToken));
+          }.check(done));
+        });
+      });
+
+      describe("then connect with previous session info", function() {
+        it("should raise authentication error", function(done) {
+          var conn2 = new sf.Connection({
+            accessToken: sessionInfo.accessToken,
+            instanceUrl: sessionInfo.instanceUrl,
+            logLevel: config.logLevel
+          });
+          setTimeout(function() { // wait a moment
+            conn2.query("SELECT Id FROM User", function(err, res) {
+              assert.ok(err && _.isString(err.message));
+            }.check(done));
+          }, 10000);
+        });
+      });
+    });
+
+
+  });
+
+
+/*------------------------------------------------------------------------*/
+if (testUtils.isNodeJS) {
+
+  /**
+   *
+   */
+  describe("login by oauth2 web server flow", function() {
+    var newConn = new sf.Connection({
+      oauth2: {
+        clientId : config.clientId,
+        clientSecret : config.clientSecret,
+        redirectUri : config.redirectUri
+      },
+      logLevel : config.logLevel
+    });
+    var accessToken, instanceUrl;
+
+    it("should login and get access tokens", function(done) {
+      async.waterfall([
+        function(cb) {
+          authorize(newConn.oauth2.getAuthorizationUrl(), config.username, config.password, cb);
+        },
+        function(params, cb) {
+          newConn.authorize(params.code, cb);
+        }
+      ], function(err, userInfo) {
+        if (err) { return done(err); }
+        assert.ok(_.isString(userInfo.id));
+        assert.ok(_.isString(userInfo.organizationId));
+        assert.ok(_.isString(userInfo.url));
+        assert.ok(_.isString(newConn.accessToken));
+        assert.ok(_.isString(newConn.refreshToken));
+        accessToken = newConn.accessToken;
+        instanceUrl = newConn.instanceUrl;
+      }.check(done));
+    });
+
+    describe("then do simple query", function() {
+      it("should return some records", function(done) {
+        newConn.query("SELECT Id FROM User", function(err, res) {
+          assert.ok(_.isArray(res.records));
+        }.check(done));
+      });
+    });
+
+    describe("then make access token invalid", function() {
+      var newAccessToken, refreshCount = 0;
+      it("should return responses", function(done) {
+        newConn.accessToken = "invalid access token";
+        newConn.removeAllListeners("refresh");
+        newConn.on("refresh", function(at) {
+          newAccessToken = at;
+          refreshCount++;
+        });
+        newConn.query("SELECT Id FROM User", function(err, res) {
+          assert.ok(refreshCount === 1);
+          assert.ok(_.isString(newAccessToken));
+          assert.ok(_.isArray(res.records));
+          accessToken = newAccessToken;
+        }.check(done));
+      });
+    });
+
+    describe("then make access token invalid and call api in parallel", function() {
+      var newAccessToken, refreshCount = 0;
+      it("should return responses", function(done) {
+        newConn.accessToken = "invalid access token";
+        newConn.removeAllListeners("refresh");
+        newConn.on("refresh", function(at) {
+          newAccessToken = at;
+          refreshCount++;
+        });
+        async.parallel([
+          function(cb) {
+            newConn.query('SELECT Id FROM User', cb);
+          },
+          function(cb) {
+            newConn.describeGlobal(cb);
+          },
+          function(cb) {
+            newConn.sobject('User').describe(cb);
+          }
+        ], function(err, results) {
+          assert.ok(refreshCount === 1);
+          assert.ok(_.isString(newAccessToken));
+          assert.ok(_.isArray(results));
+          assert.ok(_.isArray(results[0].records));
+          assert.ok(_.isArray(results[1].sobjects));
+          assert.ok(_.isArray(results[2].fields));
+          accessToken = newAccessToken;
+        }.check(done));
+      });
+    });
+
+    describe("then expire both access token and refresh token", function() {
+      it("should return error response", function(done) {
+        newConn.accessToken = "invalid access token";
+        newConn.refreshToken = "invalid refresh token";
+        newConn.query("SELECT Id FROM User", function(err) {
+          assert.ok(err instanceof Error);
+          assert.ok(err.name === "invalid_grant");
+        }.check(done));
+      });
+    });
+
+  });
+
+}
+/*------------------------------------------------------------------------*/
+
+});
+

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -20,16 +20,8 @@ describe("connection", function() {
   /**
    *
    */
-  describe("login", function() {
-    it("should login by username and password", function(done) {
-      conn.login(config.username, config.password, function(err, userInfo) {
-        if (err) { throw err; }
-        assert.ok(_.isString(conn.accessToken));
-        assert.ok(_.isString(userInfo.id));
-        assert.ok(_.isString(userInfo.organizationId));
-        assert.ok(_.isString(userInfo.url));
-      }.check(done));
-    });
+  before(function(done) {
+    testUtils.establishConnection(conn, config, done);
   });
 
   var accountId, account;
@@ -396,7 +388,7 @@ describe("connection", function() {
         }.check(done));
       });
     });
-    
+
     /**
      *
      */
@@ -485,140 +477,6 @@ describe("connection", function() {
       assert.ok(limitInfo.apiUsage.limit > limitInfo.apiUsage.used);
     });
   });
-
-/*------------------------------------------------------------------------*/
-if (testUtils.isNodeJS) {
-
-  /**
-   *
-   */
-  describe("logout by soap api", function() {
-    var sessionInfo;
-    it("should logout", function(done) {
-      sessionInfo = {
-        accessToken : conn.accessToken,
-        instanceUrl : conn.instanceUrl
-      };
-      conn.logout(function(err) {
-        if (err) { throw err; }
-        assert.ok(_.isNull(conn.accessToken));
-      }.check(done));
-    });
-
-    describe("then connect with previous session info", function() {
-      it("should raise authentication error", function(done) {
-        conn = testUtils.createConnection(config);
-        conn.initialize(sessionInfo);
-        setTimeout(function() { // wait a moment
-          conn.query("SELECT Id FROM User", function(err, res) {
-            assert.ok(err && _.isString(err.message));
-          }.check(done));
-        }, 10000);
-      });
-    });
-  });
-
-  /**
-   *
-   */
-  describe("login by oauth2", function() {
-    var newConn = new sf.Connection({
-      oauth2: {
-        clientId : config.clientId,
-        clientSecret : config.clientSecret,
-        redirectUri : config.redirectUri
-      },
-      logLevel : config.logLevel
-    });
-
-    it("should login and get access tokens", function(done) {
-      async.waterfall([
-        function(cb) {
-          authorize(newConn.oauth2.getAuthorizationUrl(), config.username, config.password, cb);
-        },
-        function(params, cb) {
-          newConn.authorize(params.code, cb);
-        }
-      ], function(err, userInfo) {
-        if (err) { return done(err); }
-        assert.ok(_.isString(userInfo.id));
-        assert.ok(_.isString(userInfo.organizationId));
-        assert.ok(_.isString(userInfo.url));
-        assert.ok(_.isString(newConn.accessToken));
-        assert.ok(_.isString(newConn.refreshToken));
-      }.check(done));
-    });
-
-    describe("then do simple query", function() {
-      it("should return some records", function(done) {
-        newConn.query("SELECT Id FROM User", function(err, res) {
-          assert.ok(_.isArray(res.records));
-        }.check(done));
-      });
-    });
-
-    describe("then make access token invalid", function() {
-      var newAccessToken, refreshCount = 0;
-      it("should return responses", function(done) {
-        newConn.accessToken = "invalid access token";
-        newConn.removeAllListeners("refresh");
-        newConn.on("refresh", function(at) {
-          newAccessToken = at;
-          refreshCount++;
-        });
-        newConn.query("SELECT Id FROM User", function(err, res) {
-          assert.ok(refreshCount === 1);
-          assert.ok(_.isString(newAccessToken));
-          assert.ok(_.isArray(res.records));
-        }.check(done));
-      });
-    });
-
-    describe("then make access token invalid and call api in parallel", function() {
-      var newAccessToken, refreshCount = 0;
-      it("should return responses", function(done) {
-        newConn.accessToken = "invalid access token";
-        newConn.removeAllListeners("refresh");
-        newConn.on("refresh", function(at) {
-          newAccessToken = at;
-          refreshCount++;
-        });
-        async.parallel([
-          function(cb) {
-            newConn.query('SELECT Id FROM User', cb);
-          },
-          function(cb) {
-            newConn.describeGlobal(cb);
-          },
-          function(cb) {
-            newConn.sobject('User').describe(cb);
-          }
-        ], function(err, results) {
-          assert.ok(refreshCount === 1);
-          assert.ok(_.isString(newAccessToken));
-          assert.ok(_.isArray(results));
-          assert.ok(_.isArray(results[0].records));
-          assert.ok(_.isArray(results[1].sobjects));
-          assert.ok(_.isArray(results[2].fields));
-        }.check(done));
-      });
-    });
-
-    describe("then expire both access token and refresh token", function() {
-      it("should return error response", function(done) {
-        newConn.accessToken = "invalid access token";
-        newConn.refreshToken = "invalid refresh token";
-        newConn.query("SELECT Id FROM User", function(err) {
-          assert.ok(err instanceof Error);
-          assert.ok(err.name === "invalid_grant");
-        }.check(done));
-      });
-    });
-
-  });
-
-}
-/*------------------------------------------------------------------------*/
 
 });
 


### PR DESCRIPTION
`Connection#logout()` is only for SOAP sessions. Enable logout for OAuth2 based sessions using session revoke endpoint.
