### PR TITLE
Add a 'poll' event to Batch.poll allowing applications to track and report on batch progress

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -450,6 +450,7 @@ Batch.prototype.poll = function(interval, timeout) {
         } else if (res.state === "Completed") {
           self.retrieve();
         } else {
+          self.emit('poll', res);
           setTimeout(poll, interval);
         }
       }


### PR DESCRIPTION
I'm in the process of writing a salesforce data migration tool for a client and I've written an application that utilizes jsforce to query data from their main org and populate the data (via bulk load jobs) into their _developer sandbox_ orgs to their liking so they can work on smaller code changes aginst production data without the need for a full sandbox.  I've included a new 'poll' event that is emitted from within the `Batch.poll` function that I can listen to and display bulk job load progress back to the end users.

Users are getting impatient when the Salesforce queue is backed up and they have no insight (without going into the Salesforce UI) into what is "taking so long".  Being able to tie into the polling allows the application to not only display an active "state" of the job to the user but to also show them progress as their job is processed by Salesforce give them a much better experience.

The alternative was to either implement the poll functionality with a custom function or to repeatedly call `Batch.check` which is double duty on the API.  With this one line change we can now simply:

``` javascript
batch.on('poll', function(res) { 
  // display progress of a job 
});
```
