### PR TITLE
Fix out of memory when bulk loading large amount of record array

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -324,6 +324,7 @@ util.inherits(CSVStream, RecordStream);
  * @param {Record} record - Record object
  */
 CSVStream.prototype.send = function(record) {
+  this.receivable = false; // ignore incoming CSV data from stream
   if (!this.wroteHeaders) {
     if (!this.headers) {
       this.headers = CSV.extractHeaders([ record ]);
@@ -342,8 +343,8 @@ CSVStream.prototype.send = function(record) {
  */
 CSVStream.prototype.end = function(record) {
   if (record) { this.send(record); }
-  this.readable = false;
   this.sendable = false;
+  this.receivable = false;
   this._stream.emit("end");
 };
 
@@ -351,6 +352,8 @@ CSVStream.prototype.end = function(record) {
  * @private
  */
 CSVStream.prototype._handleData = function(data, enc) {
+  // ignore received CSV input from stream
+  if (!this.receivable) { return; }
   this._buffer.push([ data, enc ]);
 };
 
@@ -358,6 +361,8 @@ CSVStream.prototype._handleData = function(data, enc) {
  * @private
  */
 CSVStream.prototype._handleEnd = function(data, enc) {
+  // ignore received CSV input from stream
+  if (!this.receivable) { return; }
   var self = this;
   if (data) {
     this._buffer.push([ data, enc ]);


### PR DESCRIPTION
Bulk API load() seems consuming a lot of memory and ocasionally hungs up when loading more than 5,000 records from array.
