### PR TITLE
autoFetch query wastes request even maxFetch is explicitly set

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -433,7 +433,10 @@ Query.prototype.execute = function(options, callback) {
 
     // streaming record instances
     for (var i=0, l=data.records.length; i<l; i++) {
-      if (self.totalFetched >= maxFetch) { break; }
+      if (self.totalFetched >= maxFetch) {
+        self._finished = true;
+        break;
+      }
       var record = data.records[i];
       if (self._paused) { 
         self._buffer.push(record);
@@ -441,7 +444,7 @@ Query.prototype.execute = function(options, callback) {
         self.emit('record', record, self.totalFetched++, self);
       }
     }
-    self._finished = data.done;
+    self._finished = self._finished || data.done;
     if (data.nextRecordsUrl) {
       self._locator = data.nextRecordsUrl.split('/').pop();
     }


### PR DESCRIPTION
In query with `autoFetch` option, API requests are called till the end even if the `maxFetch` option is explicitly set.
