### PR TITLE
Change behavior of returning records in Query#execute() callback

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -239,7 +239,7 @@ Query.prototype.scanAll = function(scanAll) {
  * @private
  */
 var ResponseTargets = Query.ResponseTargets = {};
-[ "QueryResult", "Records", "AllRecords", "SingleRecord", "Count" ].forEach(function(f) {
+[ "QueryResult", "Records", "SingleRecord", "Count" ].forEach(function(f) {
   ResponseTargets[f] = f;
 });
 
@@ -382,22 +382,28 @@ Query.prototype.execute = function(options, callback) {
     promiseCallback(err);
   });
 
-  // if response target is "AllRecords", store all fetched records till the end and then fire response event.
-  if (options.responseTarget === ResponseTargets.AllRecords) {
-    var records = [];
-    this.on('record', function onRecord(record) { records.push(record); });
-    this.once('end', function() {
-      self.removeListener('record', onRecord);
-      self.emit('response', records, self);
-    });
-  }
+  // collect fetched records in array
+  // only when response target is Records and
+  // either callback or chaining promises are available to this query.
+  this.once('fetch', function() {
+    if (options.responseTarget === ResponseTargets.Records && (self._chaining || callback)) {
+      logger.debug('--- collecting all fetched records ---');
+      var records = [];
+      var onRecord = function(record) { records.push(record); };
+      self.on('record', onRecord);
+      self.once('end', function() {
+        self.removeListener('record', onRecord);
+        self.emit('response', records, self);
+      });
+    }
+  });
 
   // start actual query
   logger.debug('>>> Query start >>>');
-  var qry = this._execute(options).then(function(rets) {
-    logger.debug('...Query finished');
+  this._execute(options).then(function() {
+    logger.debug('*** Query finished ***');
   }).fail(function(err) {
-    logger.debug('...Query error');
+    logger.debug('--- Query error ---');
     self.emit('error', err);
   });
 
@@ -429,6 +435,7 @@ Query.prototype._execute = function(options) {
   ).then(function(url) {
     return self._conn._request(url);
   }).then(function(data) {
+    self.emit("fetch");
     self.totalSize = data.totalSize;
     var res;
     switch(responseTarget) {
@@ -445,7 +452,7 @@ Query.prototype._execute = function(options) {
         res = data;
     }
     // only fire response event when it should be notified per fetch
-    if (responseTarget !== ResponseTargets.AllRecords) {
+    if (responseTarget !== ResponseTargets.Records) {
       self.emit("response", res, self);
     }
 
@@ -473,6 +480,7 @@ Query.prototype._execute = function(options) {
     } else {
       if (!self._paused) { self.close(); }
     }
+    return res;
   });
 };
 
@@ -639,6 +647,7 @@ Query.prototype.update = function(mapping, type, callback) {
  * @returns {Promise.<S1|S2>}
  */
 Query.prototype.then = function(onResolved, onReject) {
+  this._chaining = true;
   if (!this._closed && this._paused) { this.execute(); }
   return this._deferred.promise.then.apply(this._deferred.promise, arguments);
 };


### PR DESCRIPTION
#36

Add an option or change default behavior to return the fetched record results when executing query with `autoFetch` option.
