### PR TITLE
Change order of response event and API limit check

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -305,8 +305,6 @@ Connection.prototype._request = function(params, callback, options) {
 
     logger.debug("<response> status=" + response.statusCode + ", url=" + params.url);
 
-    self.emit('response', response.statusCode, response.body, response);
-
     // log api usage and its quota
     if (response.headers && response.headers["sforce-limit-info"]) {
       var apiUsage = response.headers["sforce-limit-info"].match(/api\-usage=(\d+)\/(\d+)/)
@@ -319,6 +317,8 @@ Connection.prototype._request = function(params, callback, options) {
         };
       }
     }
+
+    self.emit('response', response.statusCode, response.body, response);
 
     // Refresh token if status code requires authentication
     // when oauth2 info and refresh token is available.


### PR DESCRIPTION
API limit check should be before response event firing, to check it in assigned listeners.
