### PR TITLE
Clean bulk jobs after Query#update/destroy() query error

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -776,9 +776,7 @@ Bulk.prototype.query = function(soql) {
  * @returns {Bulk~Job}
  */
 Bulk.prototype.createJob = function(type, operation, options) {
-  var job = new Job(this, type, operation, options);
-  job.open();
-  return job;
+  return new Job(this, type, operation, options);
 };
 
 /**


### PR DESCRIPTION
Query#update() sometime doesn't clean up jobs for bulk updating. It is caused by query error and error handling doesn't cancel it.
