### PR TITLE
on job error, it was not calling callback with error

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -734,6 +734,9 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
     options = null;
   }
   var job = this.createJob(type, operation, options);
+  job.on('error', function (error) {
+    callback(error);
+  });
   var batch = job.createBatch();
   var cleanup = function() { job.close(); };
   batch.on('response', cleanup);


### PR DESCRIPTION
our server's callback is never called when there's a job error