### PR TITLE
Polling timeout message is not descriptive so that cannot continue the bulk batch

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -479,7 +479,7 @@ Batch.prototype.poll = function(interval, timeout) {
   var poll = function() {
     var now = new Date().getTime();
     if (startTime + timeout < now) {
-      self.emit('error', new Error("polling time out"));
+      self.emit('error', new Error("Polling time out. Job Id = " + jobId + " , batch Id = " + batchId));
       return;
     }
     self.check(function(err, res) {

--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -635,6 +635,7 @@ AsyncResultLocator.prototype.check = function(callback) {
   var meta = this._meta;
   return this.then(function(results) {
     var ids = _.isArray(results) ? _.map(results, function(res){ return res.id; }) : results.id;
+    self._ids = ids;
     return meta.checkStatus(ids);
   }).thenCall(callback);
 };
@@ -652,7 +653,11 @@ AsyncResultLocator.prototype.poll = function(interval, timeout) {
   var poll = function() {
     var now = new Date().getTime();
     if (startTime + timeout < now) {
-      self.emit('error', new Error("polling time out"));
+      var errMsg = "Polling time out.";
+      if (self._ids) {
+        errMsg += " Process Id = " + self._ids;
+      }
+      self.emit('error', new Error(errMsg));
       return;
     }
     self.check().then(function(results) {


### PR DESCRIPTION
If bulk batch result polling timeouts, it shows error "Polling time out" and no job id or batch id was returned. It is difficult to watch the executed result afterward.