### PR TITLE
Submitting batches via bulk.load when access key has expired errors out

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -701,8 +701,12 @@ Bulk.prototype._request = function(params, callback) {
     beforesend: function(conn, params) {
       params.headers["X-SFDC-SESSION"] = conn.accessToken;
     },
+    isSessionExpired: function(response) {
+      return response.statusCode === 400 &&
+        /<exceptionCode>InvalidSessionId<\/exceptionCode>/.test(response.body);
+    },
     parseError: function(error) {
-      var err = new Error(error.error.exceptionMessage)
+      var err = new Error(error.error.exceptionMessage);
       err.code = err.name = error.error.exceptionCode;
       return err;
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -286,6 +286,22 @@ Connection.prototype._request = function(params, callback, options) {
   // for connection in canvas with signed request
   if (this.signedRequest) { options.signedRequest = this.signedRequest; }
 
+  // for session expiraty detection
+  var isSessionExpired = options.isSessionExpired || function(response) {
+    return response.statusCode === 401;
+  };
+
+  // for error detection
+  var isErrorResponse = options.isErrorResponse || function(response) {
+    return response.statusCode >= 400;
+  };
+
+  // for parsing error message in response
+  var parseError = options.parseError || function(errs) {
+    var err = _.isArray(errs) ? errs[0] : errs;
+    if (_.isObject(err) && _.isString(err.message)) { return err; }
+  };
+
   self.emit('request', params.method, params.url, params);
 
   logger.debug("<request> method=" + params.method + ", url=" + params.url);
@@ -307,7 +323,7 @@ Connection.prototype._request = function(params, callback, options) {
 
     // log api usage and its quota
     if (response.headers && response.headers["sforce-limit-info"]) {
-      var apiUsage = response.headers["sforce-limit-info"].match(/api\-usage=(\d+)\/(\d+)/)
+      var apiUsage = response.headers["sforce-limit-info"].match(/api\-usage=(\d+)\/(\d+)/);
       if (apiUsage) {
         self.limitInfo = {
           apiUsage: {
@@ -322,7 +338,7 @@ Connection.prototype._request = function(params, callback, options) {
 
     // Refresh token if status code requires authentication
     // when oauth2 info and refresh token is available.
-    if (response.statusCode === 401 &&
+    if (isSessionExpired(response) &&
         (self._refreshDelegate || (self.oauth2 && self.refreshToken))) {
       // Access token may be refreshed before the response
       if (self._initializedAt > requestTime) {
@@ -353,13 +369,9 @@ Connection.prototype._request = function(params, callback, options) {
                     parseText;
 
     var err;
-    if (response.statusCode >= 400) {
+    if (isErrorResponse(response)) {
       var error;
       try {
-        var parseError = options.parseError || function(errs) {
-          var err = _.isArray(errs) ? errs[0] : errs;
-          if (_.isObject(err) && _.isString(err.message)) { return err; }
-        };
         error = parseError(parseBody(response.body));
       } catch(e) {}
       if (!error) {


### PR DESCRIPTION
If I instantiate a Connection using a refresh token, and then use the Connection to bulk load records, I receive an error if the access token is invalid. 
When the access token has expired the returned HTTP status code is 400, not 401 as expected. This causes the Connection to return an error rather then trying to fetch another access token.