### PR TITLE
add emit poll event when polling a deploy

### DIFF
--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -664,7 +664,8 @@ AsyncResultLocator.prototype.poll = function(interval, timeout) {
       var resultArr = _.isArray(results) ? results : [ results ];
       for (var i=0, len=resultArr.length; i<len; i++) {
         var result = resultArr[i];
-        if (result && !result.done) {
+        if (result && !result.done) {	
+          self.emit('poll', result);
           done = false;
         }
       }


### PR DESCRIPTION
This change adds a poll event to the polling method in the Metadata class. It's useful for when you need constant updates during a deployment on the current statues.