### PR TITLE
Remain bulk job opened even if polling timeout occurred

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -479,7 +479,9 @@ Batch.prototype.poll = function(interval, timeout) {
   var poll = function() {
     var now = new Date().getTime();
     if (startTime + timeout < now) {
-      self.emit('error', new Error("Polling time out. Job Id = " + jobId + " , batch Id = " + batchId));
+      var err = new Error("Polling time out. Job Id = " + jobId + " , batch Id = " + batchId);
+      err.name = 'PollingTimeout';
+      self.emit('error', err);
       return;
     }
     self.check(function(err, res) {
@@ -765,8 +767,13 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
     batch = null;
     job.close();
   };
+  var cleanupOnError = function(err) {
+    if (err.name !== 'PollingTimeout') {
+      cleanup();
+    }
+  };
   batch.on('response', cleanup);
-  batch.on('error', cleanup);
+  batch.on('error', cleanupOnError);
   batch.on('queue', function() { batch.poll(self.pollInterval, self.pollTimeout); });
   return batch.execute(input, callback);
 };


### PR DESCRIPTION
Do not close job when polling timeout error occurred in Bulk#load()