### PR TITLE
Bulk hard delete is not working, causes job error

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -80,10 +80,12 @@ Job.prototype.open = function(callback) {
 
   // if not requested opening job
   if (!this._jobInfo) {
+    var operation = this.operation.toLowerCase();
+    if (operation === 'harddelete') { operation = 'hardDelete'; }
     var body = [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<jobInfo  xmlns="http://www.force.com/2009/06/asyncapi/dataload">',
-        '<operation>' + this.operation.toLowerCase() + '</operation>',
+        '<operation>' + operation + '</operation>',
         '<object>' + this.type + '</object>',
         (this.options.extIdField ?
          '<externalIdFieldName>'+this.options.extIdField+'</externalIdFieldName>' :


### PR DESCRIPTION
If we call 'Bulk#load()' with operation `hardDelete`, it will raise job error
```
InvalidJob: Unable to parse Job
```