### PR TITLE
Possible to set an assignment rule id to be run on bulkInsert

### DIFF
--- a/build/jsforce-core.js
+++ b/build/jsforce-core.js
@@ -4993,8 +4993,8 @@ SObject.prototype.bulkload = function(operation, options, input, callback) {
  * @returns {Bulk~Batch}
  */
 SObject.prototype.insertBulk =
-SObject.prototype.createBulk = function(input, callback) {
-  return this.bulkload("insert", input, callback);
+SObject.prototype.createBulk = function(options, input, callback) {
+  return this.bulkload("insert", options, input, callback);
 };
 
 /**

--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -93,6 +93,9 @@ Job.prototype.open = function(callback) {
          '<externalIdFieldName>'+this.options.extIdField+'</externalIdFieldName>' :
          ''),
         '<contentType>CSV</contentType>',
+        (this.options.assignmentRuleId ? 
+          '<assignmentRuleId>' + this.options.assignmentRuleId + '</assignmentRuleId>' :
+          ''),
       '</jobInfo>'
     ].join('');
 
@@ -746,7 +749,7 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
   if (!type || !operation) {
     throw new Error("Insufficient arguments. At least, 'type' and 'operation' are required.");
   }
-  if (operation.toLowerCase() !== 'upsert') { // options is only for upsert operation
+  if ((operation.toLowerCase() !== 'upsert') && (operation.toLowerCase() !== 'insert')) { // options is only for upsert operation
     callback = input;
     input = options;
     options = null;


### PR DESCRIPTION
This fix a problem of not running assignment rule. However, you must specify the assignment rule to be executed.