### PR TITLE
Add Bulk API Job option to change concurrency mode

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -30,6 +30,7 @@ var inherits     = require('inherits'),
  * @param {String} [operation] - Bulk load operation ('insert', 'update', 'upsert', 'delete', or 'hardDelete')
  * @param {Object} [options] - Options for bulk loading operation
  * @param {String} [options.extIdField] - External ID field name (used when upsert operation).
+ * @param {String} [options.concurrencyMode] - 'Serial' or 'Parallel'. Defaults to Parallel.
  * @param {String} [jobId] - Job ID (if already available)
  */
 var Job = function(bulk, type, operation, options, jobId) {
@@ -91,6 +92,9 @@ Job.prototype.open = function(callback) {
         '<object>' + this.type + '</object>',
         (this.options.extIdField ?
          '<externalIdFieldName>'+this.options.extIdField+'</externalIdFieldName>' :
+         ''),
+        (this.options.concurrencyMode ?
+         '<concurrencyMode>'+this.options.concurrencyMode+'</concurrencyMode>' :
          ''),
         '<contentType>CSV</contentType>',
       '</jobInfo>'
@@ -737,6 +741,7 @@ Bulk.prototype._request = function(request, callback) {
  * @param {String} operation - Bulk load operation ('insert', 'update', 'upsert', 'delete', or 'hardDelete')
  * @param {Object} [options] - Options for bulk loading operation
  * @param {String} [options.extIdField] - External ID field name (used when upsert operation).
+ * @param {String} [options.concurrencyMode] - 'Serial' or 'Parallel'. Defaults to Parallel.
  * @param {Array.<Record>|stream.Stream|String} [input] - Input source for bulkload. Accepts array of records, CSV string, and CSV data input stream in insert/update/upsert/delete/hardDelete operation, SOQL string in query operation.
  * @param {Callback.<Array.<RecordResult>|Array.<Bulk~BatchResultInfo>>} [callback] - Callback function
  * @returns {Bulk~Batch}


### PR DESCRIPTION
There are some options supported by the Bulk API that are missing from jsforce. This simple commit adds concurrencyMode, which allows users to toggle between Parallel (the default in Salesforce) and Serial.

From the Salesforce docs:

**Parallel**: Process batches in parallel mode. This is the default value.
**Serial**: Process batches in serial mode. Processing in parallel can cause database contention. When this is severe, the job may fail. If you're experiencing this issue, submit the job with serial concurrency mode. This guarantees that batches are processed one at a time. Note that using this option may significantly increase the processing time for a job.

Here's the full list of supported options:
https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_reference_jobinfo.htm