### PR TITLE
License in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "git://github.com/jsforce/jsforce.git"
   },
+  "license": "MIT",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
[npm >= 2.10.0](https://github.com/npm/npm/releases/tag/v2.10.0) warns when there is no license field in the package.json. This sets the license field to be MIT.