### PR TITLE
Bubble up errors for bulk

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -636,7 +636,7 @@ Batch.prototype.retrieve = function(callback) {
     }
     self.emit('response', results);
     return results;
-  }, function(err) {
+  }).catch(function(err) {
     self.emit('error', err);
     throw err;
   }).thenCall(callback);
@@ -794,6 +794,8 @@ Bulk.prototype.query = function(soql) {
     var r = results[0];
     var result = self.job(r.jobId).batch(r.batchId).result(r.id);
     result.stream().pipe(dataStream);
+  }).catch(function(err) {
+    recordStream.emit('error', err);
   });
   return recordStream;
 };


### PR DESCRIPTION
This emits the error event on the returned stream for polling a batch and for
loading a query. Before, execution would just hang indefinitely. Resolves #227.