### PR TITLE
Return subscription object

### DIFF
--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -32,11 +32,10 @@ var Topic = module.exports = function(streaming, name) {
  *
  * @method Streaming~Topic#subscribe
  * @param {Callback.<Streaming~StreamingMesasge>} listener - Streaming message listener
- * @returns {Streaming~Topic}
+ * @returns {Subscription} - Faye subscription object
  */
 Topic.prototype.subscribe = function(listener) {
-  this._streaming.subscribe(this.name, listener);
-  return this;
+  return this._streaming.subscribe(this.name, listener);
 };
 
 /**
@@ -92,7 +91,7 @@ Streaming.prototype.topic = function(name) {
  *
  * @param {String} name - Topic name
  * @param {Callback.<Streaming~StreamingMessage>} listener - Streaming message listener
- * @returns {Streaming}
+ * @returns {Subscription} - Faye subscription object
  */
 Streaming.prototype.subscribe = function(name, listener) {
   if (!this._fayeClient) {
@@ -101,8 +100,7 @@ Streaming.prototype.subscribe = function(name, listener) {
     }
     this._fayeClient = this._createClient();
   }
-  this._fayeClient.subscribe("/topic/"+name, listener);
-  return this;
+  return this._fayeClient.subscribe("/topic/"+name, listener);
 };
 
 /**


### PR DESCRIPTION
This resolves #224 by returning the subscription object for the streaming api. This does break the existing chaining api, but it is unlikely the chaining feature is used, so the impact of breaking this API _should_ be minimal.