### PR TITLE
Accept bulkload options in all type of operation

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -751,7 +751,7 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
   if (!type || !operation) {
     throw new Error("Insufficient arguments. At least, 'type' and 'operation' are required.");
   }
-  if (operation.toLowerCase() !== 'upsert') { // options is only for upsert operation
+  if (!_.isObject(options) || options.constructor !== Object) { // when options is not plain hash object, it is omitted
     callback = input;
     input = options;
     options = null;


### PR DESCRIPTION
To pass options other than external id in upsert operation, options must be passed to batch job options in every bulkload operation.
In order to keep the current behavior the options parameter also can be omittable.