### PR TITLE
describe instead of retrieve

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -548,6 +548,7 @@ Connection.prototype.retrieve = function(type, ids, options, callback) {
   }
   return Promise.all(
     _.map(ids, function(id) {
+      if (!id) { return Promise.reject(new Error('Invalid record ID. Specify valid record ID value')).thenCall(callback); }
       var url = [ self._baseUrl(), "sobjects", type, id ].join('/');
       return self.request(url);
     })


### PR DESCRIPTION
https://github.com/jsforce/jsforce/blob/master/lib/connection.js#L545

`conn.sobject(type).retrieve(undefined);` will result in the describe operation for that type being executed.  The result will be the JSON object that describes the type.  This should either throw or return undefined.