### PR TITLE
REPL .register fails

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -279,7 +279,7 @@ function register(clientName, clientConfig, callback) {
     "redirectUri": "Input redirect URI : ",
     "loginUrl": "Input login URL (default is https://login.salesforce.com) : "
   };
-  new Promise().then(function() {
+  Promise.resolve().then(function() {
     var deferred = Promise.defer();
     if (registry.getClient(clientName)) {
       var msg = "Client '"+clientName+"' is already registered. Are you sure you want to override ? [yN] : ";
@@ -311,7 +311,7 @@ function register(clientName, clientConfig, callback) {
         }
         return deferred.promise;
       });
-    }, new Promise());
+    }, Promise.resolve());
   }).then(function() {
     registry.registerClient(clientName, clientConfig);
     print("Client registered successfully.");


### PR DESCRIPTION
In `/node_modules/promise/lib/core.js:8`
```
  if (typeof fn !== 'function') throw new TypeError('not a function')
                                      ^
TypeError: not a function
```
