### PR TITLE
Fix toXML function to handle values with XML special characters

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -166,7 +166,12 @@ function toXML(name, value) {
       }
       value = elems.join('');
     } else {
-      value = String(value);
+      value = String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
     }
     var startTag = name ? '<' + name + (attrs.length > 0 ? ' ' + attrs.join(' ') : '') + '>' : '';
     var endTag = name ? '</' + name + '>' : '';


### PR DESCRIPTION
Here is a fix for this error when calling a SOAP method:

{ [soapenv:Client: The entity name must immediately follow the '&' in the entity reference.] name: 'soapenv:Client', errorCode: 'soapenv:Client' }