### PR TITLE
RecordStream#map() and RecordStream#filter is broken

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -46,7 +46,7 @@ RecordStream.prototype._transform = function(record, enc, callback) {
  * @returns {RecordStream}
  */
 RecordStream.prototype.map = function(fn) {
-  return this.pipe(RecordStream.map());
+  return this.pipe(RecordStream.map(fn));
 };
 
 /**
@@ -56,7 +56,7 @@ RecordStream.prototype.map = function(fn) {
  * @returns {RecordStream}
  */
 RecordStream.prototype.filter = function(fn) {
-  return this.pipe(RecordStream.filter());
+  return this.pipe(RecordStream.filter(fn));
 };
 
 


### PR DESCRIPTION
In 1.5.0, record stream map function and filter function doesn't yield any value to piped downstream.