### PR TITLE
Setting default connection version to the latest version

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,7 +22,7 @@ var events  = require('events'),
 var defaults = {
   loginUrl: "https://login.salesforce.com",
   instanceUrl: "",
-  version: "34.0"
+  version: "35.0"
 };
 
 /**


### PR DESCRIPTION
Need to update the default version so new tooling objects like SandboxInfo can be retrieved.