### PR TITLE
Add node.js 4.2 and stable to target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-- 0.10
-- 0.12
+- "0.10"
+- "0.12"
+- "4.2"
+- "stable"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
In Travis CI, include Node.js 4.2 and stable version to the test target.