### PR TITLE
Use fail alias for promise.catch

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -643,7 +643,7 @@ Batch.prototype.retrieve = function(callback) {
     }
     self.emit('response', results);
     return results;
-  }).catch(function(err) {
+  }).fail(function(err) {
     self.emit('error', err);
     throw err;
   }).thenCall(callback);
@@ -802,7 +802,7 @@ Bulk.prototype.query = function(soql) {
     var r = results[0];
     var result = self.job(r.jobId).batch(r.batchId).result(r.id);
     result.stream().pipe(dataStream);
-  }).catch(function(err) {
+  }).fail(function(err) {
     recordStream.emit('error', err);
   });
   return recordStream;

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -95,7 +95,7 @@ Promise.prototype.thenCall = function(callback) {
  * @param {RejectedCallback.<S>} onRejected
  * @returns {Promise.<S>}
  */
-Promise.prototype.fail = Promise.prototype.catch;
+Promise.prototype.fail = Promise.prototype['catch'];
 
 /**
  * Alias for completion


### PR DESCRIPTION
IE9 won't allow you to use the reserve word `catch` as a function, so instead I'm using the `fail` alias set up in lib/promise.js. I'm not sure if there are other issues with IE 9, but this was the one reported.

Closes #283 