### PR TITLE
Fix travis.yml cache setting for node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 sudo: false
 cache:
   directories:
-    - node-modules
+    - node_modules


### PR DESCRIPTION
Fix wrong cache directory naming `node-modules` to `node_modules`