### PR TITLE
Change download url from bitbucket to github

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 mkdir travis-phantomjs
-wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+wget https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
 tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
 export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH


### PR DESCRIPTION
As the phantomjs bitbucket download url hits rate limit frequently, change to github-hosted url by medium.