### PR TITLE
Connection#identity() returns XHR error in non-proxied environment

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -887,7 +887,10 @@ Connection.prototype.identity = function(callback) {
   ).then(function(res) {
     var url = res.identity;
     url += '?format=json&oauth_token=' + encodeURIComponent(self.accessToken);
-    return self.request(url, null, { jsonp : 'callback' });
+    var transport = Transport.JsonpTransport.supported ?
+      new Transport.JsonpTransport('callback') :
+      undefined;
+    return self.requestGet(url, { transport: transport });
   }).then(function(res) {
     self.userInfo = {
       id: res.user_id,

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -73,18 +73,12 @@ var Transport = module.exports = function() {};
  *
  * @param {Object} params - HTTP request
  * @param {Callback.<Object>} [callback] - Calback Function
- * @param {Callback.<Object>} [options] - Options
  * @returns {Promise.<Object>}
  */
-Transport.prototype.httpRequest = function(params, callback, options) {
+Transport.prototype.httpRequest = function(params, callback) {
   var deferred = Promise.defer();
   var req;
-  var httpRequest = request;
-  if (options && options.jsonp && jsonp.supported) {
-    httpRequest = jsonp.createRequest(options.jsonp);
-  } else if (options && options.signedRequest && canvas.supported) {
-    httpRequest = canvas.createRequest(options.signedRequest);
-  }
+  var httpRequest = this._getHttpRequestModule();
   var createRequest = function() {
     if (!req) {
       req = httpRequest(params, function(err, response) {
@@ -99,6 +93,54 @@ Transport.prototype.httpRequest = function(params, callback, options) {
   };
   return streamify(deferred.promise, createRequest).thenCall(callback);
 };
+
+/** @protected **/
+Transport.prototype._getHttpRequestModule = function() {
+  return request;
+};
+
+
+/**
+ * Class for JSONP request transport
+ * @class Transport~JsonpTransport
+ * @protected
+ * @extends Transport
+ * @param {String} jsonpParam - Callback parameter name for JSONP invokation.
+ */
+var JsonpTransport = Transport.JsonpTransport = function(jsonpParam) {
+  this._jsonpParam = jsonpParam;
+};
+
+inherits(JsonpTransport, Transport);
+
+/** @protected **/
+JsonpTransport.prototype._getHttpRequestModule = function() {
+  return jsonp.createRequest(this._jsonpParam);
+};
+
+JsonpTransport.supported = jsonp.supported;
+
+
+/**
+ * Class for Sfdc Canvas request transport
+ * @class Transport~CanvasTransport
+ * @protected
+ * @extends Transport
+ * @param {Object} signedRequest - Parsed signed request object
+ */
+var CanvasTransport = Transport.CanvasTransport = function(signedRequest) {
+  this._signedRequest = signedRequest;
+};
+
+inherits(CanvasTransport, Transport);
+
+/** @protected **/
+CanvasTransport.prototype._getHttpRequestModule = function() {
+  return canvas.createRequest(this._signedRequest);
+};
+
+CanvasTransport.supported = canvas.supported;
+
 
 /**
  * Class for HTTP request transport using AJAX proxy service

--- a/test/connection-meta.test.js
+++ b/test/connection-meta.test.js
@@ -198,6 +198,7 @@ describe("connection-meta", function() {
   describe("get user identity information", function() {
     it("should return user identity information", function (done) {
       conn.identity(function(err, res) {
+        if (err) { throw err; }
         assert.ok(_.isString(res.id));
         assert.ok(res.id.indexOf('https://') === 0);
         assert.ok(_.isString(res.user_id));


### PR DESCRIPTION
From visualforce page it shows following error in conslole.

```
XMLHttpRequest cannot load https://login.salesforce.com/id/00D80000000L4RvEAK/00580000001hc9JAAQ?forma…

Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
Origin 'https://mashmatrix-demo01-dev-ed--c.na6.visual.force.com' is therefore not allowed access.
```

It should use JSONP transport, but not used correctly.
