### PR TITLE
Fix canvas request failing without using proper transport

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -189,6 +189,9 @@ Connection.prototype.initialize = function(options) {
   this.signedRequest = options.signedRequest && parseSignedRequest(options.signedRequest);
   if (this.signedRequest) {
     this.accessToken = this.signedRequest.client.oauthToken;
+    if (Transport.CanvasTransport.supported) {
+      this._transport = new Transport.CanvasTransport(this.signedRequest);
+    }
   }
 
   if (options.userInfo) {


### PR DESCRIPTION
Use canvas transport when the connection has signedRequest and canvas transport is supported.