### PR TITLE
Enable to pass options in query methods to modify http headers in request

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -73,6 +73,7 @@ var Connection = module.exports = function(options) {
     options.proxyUrl ? new Transport.ProxyTransport(options.proxyUrl) : new Transport();
 
   this.callOptions = options.callOptions;
+  this.queryOptions = options.queryOptions;
 
   /*
    * Fire connection:new event to notify jsforce plugin modules
@@ -478,11 +479,17 @@ function parseIdUrl(idUrl) {
  * Execute query by using SOQL
  *
  * @param {String} soql - SOQL string
+ * @param {Object} [options] - Query options
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<QueryResult>} [callback] - Callback function
  * @returns {Query.<QueryResult>}
  */
-Connection.prototype.query = function(soql, callback) {
-  var query = new Query(this, soql);
+Connection.prototype.query = function(soql, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var query = new Query(this, soql, options);
   if (callback) {
     query.run(callback);
   }
@@ -493,11 +500,17 @@ Connection.prototype.query = function(soql, callback) {
  * Execute query by using SOQL, including deleted records
  *
  * @param {String} soql - SOQL string
+ * @param {Object} [options] - Query options
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<QueryResult>} [callback] - Callback function
  * @returns {Query.<QueryResult>}
  */
-Connection.prototype.queryAll = function(soql, callback) {
-  var query = new Query(this, soql);
+Connection.prototype.queryAll = function(soql, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var query = new Query(this, soql, options);
   query.scanAll(true);
   if (callback) {
     query.run(callback);
@@ -509,11 +522,17 @@ Connection.prototype.queryAll = function(soql, callback) {
  * Query next record set by using query locator
  *
  * @param {String} locator - Next record set locator
+ * @param {Object} [options] - Query options
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<QueryResult>} [callback] - Callback function
  * @returns {Query.<QueryResult>}
  */
-Connection.prototype.queryMore = function(locator, callback) {
-  var query = new Query(this, null, locator);
+Connection.prototype.queryMore = function(locator, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var query = new Query(this, { locator: locator }, options);
   if (callback) {
     query.run(callback);
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -25,28 +25,33 @@ var inherits = require('inherits'),
  * @template T
  * @param {Connection} conn - Connection object
  * @param {Object|String} config - Query config object or SOQL string
- * @param {String} [locator] - Locator string to fetch next record set
+ * @param {Object} [options] - Default query options
+ * @param {Boolean} [options.autoFetch] - Using auto fetch mode or not
+ * @param {Number} [options.maxFetch] - Max fetching records in auto fetch mode
+ * @param {Boolean} [options.scanAll] - Including deleted records for query target or not
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  */
-var Query = module.exports = function(conn, config, locator) {
+var Query = module.exports = function(conn, config, options) {
   Query.super_.call(this, { objectMode: true });
 
   this._conn = conn;
-  if (config) {
-    if (_.isString(config)) { // if query config is string, it is given in SOQL.
-      this._soql = config;
-    } else {
-      this._config = config;
-      this.select(config.fields);
-      if (config.includes) {
-        this.include(config.includes);
-      }
+  if (_.isString(config)) { // if query config is string, it is given in SOQL.
+    this._soql = config;
+  } else if (config.locator && config.locator.indexOf("/") >= 0) { // if locator given in url for next records
+    this._locator = config.locator.split("/").pop();
+  } else {
+    this._config = config;
+    this.select(config.fields);
+    if (config.includes) {
+      this.include(config.includes);
     }
   }
-  if (locator && locator.indexOf("/") >= 0) { // if locator given in url for next records
-    locator = locator.split("/").pop();
-  }
-  this._locator = locator;
-
+  this._options = _.defaults({
+    maxFetch: 10000,
+    autoFetch: false,
+    scanAll: false,
+    responseTarget: ResponseTargets.QueryResult
+  }, options || {});
   this._executed = false;
   this._finished = false;
   this._chaining = false;
@@ -167,7 +172,7 @@ Query.prototype.orderby = function(sort, dir) {
  * @param {String} childRelName - Child relationship name to include in query result
  * @param {Object|String} [conditions] - Conditions in JSON object (MongoDB-like), or raw SOQL WHERE clause string.
  * @param {Object|Array.<String>|String} [fields] - Fields to fetch. Format can be in JSON object (MongoDB-like), array of field names, or comma-separated field names.
- * @param {Object} [options] - Query options.
+ * @param {Object} [options] - Optional query configulations.
  * @param {Number} [options.limit] - Maximum number of records the query will return.
  * @param {Number} [options.offset] - Offset number where begins returning results.
  * @param {Number} [options.skip] - Synonym of options.offset.
@@ -201,8 +206,6 @@ Query.prototype.include = function(childRelName, conditions, fields, options) {
 };
 
 
-/** @private **/
-Query.prototype._maxFetch = 10000;
 /**
  * Setting maxFetch query option
  *
@@ -210,12 +213,10 @@ Query.prototype._maxFetch = 10000;
  * @returns {Query.<T>}
  */
 Query.prototype.maxFetch = function(maxFetch) {
-  this._maxFetch = maxFetch;
+  this._options.maxFetch = maxFetch;
   return this;
 };
 
-/** @private **/
-Query.prototype._autoFetch = false;
 /**
  * Switching auto fetch mode
  *
@@ -223,12 +224,10 @@ Query.prototype._autoFetch = false;
  * @returns {Query.<T>}
  */
 Query.prototype.autoFetch = function(autoFetch) {
-  this._autoFetch = autoFetch;
+  this._options.autoFetch = autoFetch;
   return this;
 };
 
-/** @private **/
-Query.prototype._scanAll = false;
 /**
  * Set flag to scan all records including deleted and archived.
  *
@@ -236,7 +235,7 @@ Query.prototype._scanAll = false;
  * @returns {Query.<T>}
  */
 Query.prototype.scanAll = function(scanAll) {
-  this._scanAll = scanAll;
+  this._options.scanAll = scanAll;
   return this;
 };
 
@@ -248,8 +247,6 @@ var ResponseTargets = Query.ResponseTargets = {};
   ResponseTargets[f] = f;
 });
 
-/** @private **/
-Query.prototype._responseTarget = ResponseTargets.QueryResult;
 /**
  * @protected
  * @param {String} responseTarget - Query response target
@@ -257,7 +254,7 @@ Query.prototype._responseTarget = ResponseTargets.QueryResult;
  */
 Query.prototype.setResponseTarget = function(responseTarget) {
   if (responseTarget in ResponseTargets) {
-    this._responseTarget = responseTarget;
+    this._options.responseTarget = responseTarget;
   }
   return this;
 };
@@ -271,6 +268,7 @@ Query.prototype.setResponseTarget = function(responseTarget) {
  * @param {Boolean} [options.autoFetch] - Using auto fetch mode or not
  * @param {Number} [options.maxFetch] - Max fetching records in auto fetch mode
  * @param {Boolean} [options.scanAll] - Including deleted records for query target or not
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<T>} [callback] - Callback function
  * @returns {Query.<T>}
  */
@@ -283,6 +281,7 @@ Query.prototype.run =
  * @param {Boolean} [options.autoFetch] - Using auto fetch mode or not
  * @param {Number} [options.maxFetch] - Max fetching records in auto fetch mode
  * @param {Boolean} [options.scanAll] - Including deleted records for query target or not
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<T>} [callback] - Callback function
  * @returns {Query.<T>}
  */
@@ -295,6 +294,7 @@ Query.prototype.exec =
  * @param {Boolean} [options.autoFetch] - Using auto fetch mode or not
  * @param {Number} [options.maxFetch] - Max fetching records in auto fetch mode
  * @param {Boolean} [options.scanAll] - Including deleted records for query target or not
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in query request
  * @param {Callback.<T>} [callback] - Callback function
  * @returns {Query.<T>}
  */
@@ -319,10 +319,11 @@ Query.prototype.execute = function(options, callback) {
   }
   options = options || {};
   options = {
-    responseTarget: options.responseTarget || self._responseTarget,
-    autoFetch: options.autoFetch || self._autoFetch,
-    maxFetch: options.maxFetch || self._maxFetch,
-    scanAll: options.scanAll || self._scanAll
+    headers: options.headers || self._options.headers,
+    responseTarget: options.responseTarget || self._options.responseTarget,
+    autoFetch: options.autoFetch || self._options.autoFetch,
+    maxFetch: options.maxFetch || self._options.maxFetch,
+    scanAll: options.scanAll || self._options.scanAll
   };
 
   // callback and promise resolution;
@@ -402,7 +403,11 @@ Query.prototype._execute = function(options) {
       return self._conn._baseUrl() + "/" + (scanAll ? "queryAll" : "query") + "?q=" + encodeURIComponent(soql);
     })
   ).then(function(url) {
-    return self._conn.request(url);
+    return self._conn.request({
+      method: 'GET',
+      url: url,
+      headers: options.headers
+    });
   }).then(function(data) {
     self.emit("fetch");
     self.totalSize = data.totalSize;


### PR DESCRIPTION
When calling query API the http request headers can be modified by application developers - like `Sforce-Query-Options` headers.
Closes #248.