### PR TITLE
OAuth2 revoke token request in browser environment

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -55,7 +55,8 @@ var Connection = module.exports = function(options) {
     loginUrl : options.loginUrl,
     clientId : options.clientId,
     clientSecret : options.clientSecret,
-    redirectUri : options.redirectUri
+    redirectUri : options.redirectUri,
+    proxyUrl: options.proxyUrl
   };
 
   /**

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -139,14 +139,24 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
    * @returns {Promise.<undefined>}
    */
   revokeToken : function(accessToken, callback) {
-    return this._transport.httpRequest({
-      method : 'POST',
-      url : this.revokeServiceUrl,
-      body: querystring.stringify({ token: accessToken }),
-      headers: {
-        "content-type" : "application/x-www-form-urlencoded"
-      }
-    }).then(function(response) {
+    var req;
+    if (Transport.JsonpTransport.supported) {
+      var jsonpTransport = new Transport.JsonpTransport('callback');
+      req = jsonpTransport.httpRequest({
+        method: 'GET',
+        url : this.revokeServiceUrl + '?' + querystring.stringify({ token: accessToken })
+      });
+    } else {
+      req = this._transport.httpRequest({
+        method : 'POST',
+        url : this.revokeServiceUrl,
+        body: querystring.stringify({ token: accessToken }),
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        }
+      });
+    }
+    return req.then(function(response) {
       if (response.statusCode >= 400) {
         var res = querystring.parse(response.body);
         if (!res || !res.error) {


### PR DESCRIPTION
As the revoke service URL doesn't provide CORS headers, use JSONP to request the access token revocation in browser environment.
Closes #263.