### PR TITLE
Enable retrying in tests

### DIFF
--- a/test/bin/run-test
+++ b/test/bin/run-test
@@ -14,7 +14,7 @@ try {
 // wait till the server bootup
 setTimeout(function() {
 
-  var args = "--reporter spec --require intelli-espower-loader".split(/\s+/);
+  var args = "--retries 2 --reporter spec --require intelli-espower-loader".split(/\s+/);
   if (process.argv.length > 2) {
     args.push("test/" + process.argv[2]+ ".test.js");
   }


### PR DESCRIPTION
As the test case fails frequently (especially session related tests requires OAuth2 dancing, which requires scraping via phantomjs, and not stable in automation), add retry option in mocha.