### PR TITLE
Enable retrying in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mocha": "^2.4.5",
     "power-assert": "^1.3.0",
     "require-swapper": "^0.1.6",
-    "testem": "^1.6.0",
+    "testem": "^1.7.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "webdriverio": "^4.0.4"

--- a/test/bin/run-test
+++ b/test/bin/run-test
@@ -14,7 +14,7 @@ try {
 // wait till the server bootup
 setTimeout(function() {
 
-  var args = "--reporter spec --require intelli-espower-loader".split(/\s+/);
+  var args = "--retries 2 --reporter spec --require intelli-espower-loader".split(/\s+/);
   if (process.argv.length > 2) {
     args.push("test/" + process.argv[2]+ ".test.js");
   }

--- a/test/testRunner.html
+++ b/test/testRunner.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+<title>Test'em</title>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/mocha/2.4.5/mocha.css">
+<script src="//cdnjs.cloudflare.com/ajax/libs/mocha/2.4.5/mocha.js"></script>
+<script src="/testem.js"></script>
+<script>mocha.setup('bdd')</script>
+<script src="/build/jsforce-core.js"></script>
+<script src="/build/jsforce-api-analytics.js"></script>
+<script src="/build/jsforce-api-apex.js"></script>
+<script src="/build/jsforce-api-bulk.js"></script>
+<script src="/build/jsforce-api-chatter.js"></script>
+<script src="/build/jsforce-api-metadata.js"></script>
+<script src="/build/jsforce-api-soap.js"></script>
+<script src="/build/jsforce-api-streaming.js"></script>
+<script src="/build/jsforce-api-tooling.js"></script>
+<script src="/build/test.js"></script>
+</head>
+<body>
+<div id="mocha"></div>
+<script>
+mocha.retries(2).run();
+</script>
+</body>
+</html>

--- a/testem.json
+++ b/testem.json
@@ -1,21 +1,5 @@
 {
-  "framework" : "mocha",
-  "src_files" : [
-    "lib/**/*.js",
-    "test/**/*.test.js"
-  ],
-  "serve_files" : [
-    "build/jsforce-core.js",
-    "build/jsforce-api-analytics.js",
-    "build/jsforce-api-apex.js",
-    "build/jsforce-api-bulk.js",
-    "build/jsforce-api-chatter.js",
-    "build/jsforce-api-metadata.js",
-    "build/jsforce-api-soap.js",
-    "build/jsforce-api-streaming.js",
-    "build/jsforce-api-tooling.js",
-    "build/test.js"
-  ],
+  "test_page" : "./test/testRunner.html",
   "launch_in_dev" : [ "PhantomJS" ],
   "launch_in_ci" : [ "PhantomJS" ]
 }


### PR DESCRIPTION
As the test cases fail frequently (especially session related tests requires OAuth2 dancing, which requires scraping via phantomjs, and not stable in automation), add retry option in mocha.
