### PR TITLE
Remove VERSION from core library.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -7,8 +7,7 @@
 var EventEmitter = require('events').EventEmitter;
 
 var jsforce = module.exports = new EventEmitter();
-var pkg = require('../package.json');
-jsforce.VERSION = pkg.version;
+jsforce.VERSION = '';
 jsforce.Connection = require('./connection');
 jsforce.OAuth2 = require('./oauth2');
 jsforce.Date = jsforce.SfDate = require("./date");


### PR DESCRIPTION
If you browserify the library, it would currently expose all sorts of private information; which is generated by NPM in `package.json`.

Telling users to do something to "avoid" the problem would not going to fix it. Insecure by default == insecure.