### PR TITLE
Allow base64 output when retrieving metadata

### DIFF
--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -757,9 +757,10 @@ RetrieveResultLocator.prototype.complete = function(callback) {
  * Change the retrieved result to Node.js readable stream
  *
  * @method Metadata~RetrieveResultLocator#stream
+ * @param {String} type - if "text", the base64 string will be returned, otherwise the binary data
  * @returns {stream.Readable}
  */
-RetrieveResultLocator.prototype.stream = function() {
+RetrieveResultLocator.prototype.stream = function(type) {
   var self = this;
   var resultStream = new stream.Readable();
   var reading = false;
@@ -770,7 +771,11 @@ RetrieveResultLocator.prototype.stream = function() {
       if (err) {
         resultStream.emit('error', err);
       } else {
-        resultStream.push(new Buffer(result.zipFile, 'base64'));
+        if (type === 'text') {
+          resultStream.push(result.zipFile);
+        } else {
+          resultStream.push(new Buffer(result.zipFile, 'base64'));
+        }
         resultStream.push(null);
       }
     });


### PR DESCRIPTION
specifying `conn.metadata.retrieve(...).stream('text')` allows to return straight the base64 instead of the binary data. That's wishful for instance when transferring the zip to the client instead of saving it on the server.