### PR TITLE
Transport is no longer exposed in Faye 1.2

### DIFF
--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -127,8 +127,10 @@ Streaming.prototype._getFayeClient = function(channelName) {
   if (!this._fayeClients || !this._fayeClients[clientType]) {
     this._fayeClients = this._fayeClients || {};
     this._fayeClients[clientType] = this._createClient(isGeneric);
-    if (Faye.Transport.NodeHttp) {
-      Faye.Transport.NodeHttp.prototype.batching = false; // prevent streaming API server error
+    if (this._fayeClients[clientType]._dispatcher.getConnectionTypes().indexOf('callback-polling') === -1) {
+      // prevent streaming API server error
+      this._fayeClients[clientType].selectTransport('long-polling');
+      this._fayeClients[clientType]._dispatcher._transport.batching = false;
     }
   }
   return this._fayeClients[clientType];

--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -129,7 +129,7 @@ Streaming.prototype._getFayeClient = function(channelName) {
     this._fayeClients[clientType] = this._createClient(isGeneric);
     if (this._fayeClients[clientType]._dispatcher.getConnectionTypes().indexOf('callback-polling') === -1) {
       // prevent streaming API server error
-      this._fayeClients[clientType].selectTransport('long-polling');
+      this._fayeClients[clientType]._dispatcher.selectTransport('long-polling');
       this._fayeClients[clientType]._dispatcher._transport.batching = false;
     }
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "co-prompt": "^1.0.0",
     "coffee-script": "^1.10.0",
     "commander": "^2.9.0",
-    "faye": "^1.1.2",
+    "faye": "^1.2.0",
     "inherits": "^2.0.1",
     "lodash": "^4.11.1",
     "multistream": "^2.0.5",


### PR DESCRIPTION
On new installs, calls to `Streaming#_getFayeClient` cause an uncaught `TypeError: Cannot read property 'NodeHttp' of undefined`. This is because [the latest minor release of Faye was refactored so that Faye.Transport is no longer exposed](https://github.com/faye/faye/commit/c7e4163638ac73e55c258e291694a298d0469635#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR4). This PR modifies `_getFayeClient` so instead of modifying the `NodeHttp` prototype, the function sets batching to `false` on the transport object for each new Faye client created.

I went ahead and updated the Faye version in `package.json` to make the usage more clear, even though the semver specifications are equivalent.