### PR TITLE
Use headers for requestGet, retrieve, identity, find and describe calls

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -333,7 +333,8 @@ Connection.prototype.request = function(request, options, callback) {
 Connection.prototype.requestGet = function(url, options, callback) {
   var request = {
     method: "GET",
-    url: url
+    url: url,
+    headers: options.headers
   };
   return this.request(request, options, callback);
 };
@@ -563,7 +564,7 @@ Connection.prototype.retrieve = function(type, ids, options, callback) {
     _.map(ids, function(id) {
       if (!id) { return Promise.reject(new Error('Invalid record ID. Specify valid record ID value')).thenCall(callback); }
       var url = [ self._baseUrl(), "sobjects", type, id ].join('/');
-      return self.request(url);
+      return self.request({ method: 'GET', url: url, headers: options.headers });
     })
   ).then(function(results) {
     return !isArray && _.isArray(results) ? results[0] : results;
@@ -896,23 +897,29 @@ Connection.prototype.sobject = function(type) {
 /**
  * Get identity information of current user
  *
+ * @param {Object} [options] - Identity call options
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in identity request
  * @param {Callback.<IdentityInfo>} [callback] - Callback function
  * @returns {Promise.<IdentityInfo>}
  */
-Connection.prototype.identity = function(callback) {
+Connection.prototype.identity = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
   var self = this;
   var idUrl = this.userInfo && this.userInfo.url;
   return Promise.resolve(
     idUrl ?
     { identity: idUrl } :
-    this.request(this._baseUrl())
+    this.request({ method: 'GET', url: this._baseUrl(), headers: options.headers })
   ).then(function(res) {
     var url = res.identity;
     url += '?format=json&oauth_token=' + encodeURIComponent(self.accessToken);
     var transport = Transport.JsonpTransport.supported ?
       new Transport.JsonpTransport('callback') :
       undefined;
-    return self.requestGet(url, { transport: transport });
+    return self.requestGet(url, options, { transport: transport });
   }).then(function(res) {
     self.userInfo = {
       id: res.user_id,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -333,8 +333,7 @@ Connection.prototype.request = function(request, options, callback) {
 Connection.prototype.requestGet = function(url, options, callback) {
   var request = {
     method: "GET",
-    url: url,
-    headers: options.headers
+    url: url
   };
   return this.request(request, options, callback);
 };
@@ -907,6 +906,7 @@ Connection.prototype.identity = function(options, callback) {
     callback = options;
     options = {};
   }
+  options = options || {};
   var self = this;
   var idUrl = this.userInfo && this.userInfo.url;
   return Promise.resolve(

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -540,6 +540,7 @@ ListView.prototype.describe = function(options, callback) {
     callback = options;
     options = {};
   }
+  options = options || {};
   var url =  this._conn._baseUrl() + '/sobjects/' + this.type + '/listviews/' + this.id + '/describe';
   return this._conn.request({ method: 'GET', url: url, headers: options.headers }, callback);
 };

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -201,7 +201,7 @@ SObject.prototype.find = function(conditions, fields, options, callback) {
     limit: options.limit,
     offset: options.offset || options.skip
   };
-  var query = new Query(this._conn, config);
+  var query = new Query(this._conn, config, options);
   query.setResponseTarget(Query.ResponseTargets.Records);
   if (callback) { query.run(callback); }
   return query;
@@ -530,12 +530,18 @@ ListView.prototype.results = function(callback) {
 /**
  * Returns detailed information about a list view
  *
+ * @param {Object} [options] - Identity call options
+ * @param {Object} [options.headers] - Additional HTTP request headers sent in identity request
  * @param {Callback.<ListViewDescribeInfo>} [callback] - Callback function
  * @returns {Promise.<ListViewDescribeInfo>}
  */
-ListView.prototype.describe = function(callback) {
+ListView.prototype.describe = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
   var url =  this._conn._baseUrl() + '/sobjects/' + this.type + '/listviews/' + this.id + '/describe';
-  return this._conn.request(url, callback);
+  return this._conn.request({ method: 'GET', url: url, headers: options.headers }, callback);
 };
 
 /**


### PR DESCRIPTION
This is to follow up the previous pull request https://github.com/jsforce/jsforce/pull/494. I've made more improvements based on @stomita comments, and set headers for more operations.