### PR TITLE
includes subquery behave properly and added sort fixes #11

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -195,9 +195,10 @@ Query.prototype.include = function(childRelName, conditions, fields, options) {
     conditions: conditions,
     fields: fields,
     limit: options && options.limit,
-    offset: options && (options.offset || options.skip)
+    offset: options && (options.offset || options.skip),
+    sort: options && options.sort
   };
-  this._config.includes = this._config.includes || [];
+  if (!_.isArray(this._config.includes)) this._config.includes = [];
   this._config.includes.push(childConfig);
   var childQuery = new SubQuery(this._conn, this, childConfig);
   this._children = this._children || [];


### PR DESCRIPTION
The issue here is that we expect a JSON object for the "includes".
We iterate through all the sub queries we wish to include, and call "include" recursively with the correct arguments.

```javascript
  if (_.isObject(childRelName)) {
    var includes = childRelName;
    for (var crname in includes) {
      var config = includes[crname];
      this.include(crname, config.conditions, config.fields, config);
    }
    return;
  }
```
In the end we wish to append them to a list, but the check is if the "includes" has a false value.
Then we assume "includes" is an array so we want to push the configuration we just built.
The assumption fails when the "includes" is a JSON object, which is what we expect.


Old:
```js
  this._config.includes = this._config.includes || [];
  this._config.includes.push(childConfig);
```

By checking if it is not an array, we make it one.
Then we can push our configuration into that array.

The previous value of "include" is stored in a "config" variable so we can continue to iterate through it as we recurse.
```js
  if (!_.isArray(this._config.includes)) this._config.includes = [];
  this._config.includes.push(childConfig);
```