### PR TITLE
Updates to support the API v37.0 conversion to POST methods for runTe…

### DIFF
--- a/lib/api/tooling.js
+++ b/lib/api/tooling.js
@@ -239,8 +239,8 @@ Tooling.prototype.executeAnonymous = function(body, callback) {
  * @returns {Promise.<Tooling~ExecuteAnonymousResult>}
  */
 Tooling.prototype.runTestsAsynchronous = function(classids, callback) {
-  var url = this._baseUrl() + "/runTestsAsynchronous/?classids=" + classids.join(',');
-  return this.request(url).thenCall(callback);
+  var url = this._baseUrl() + "/runTestsAsynchronous/";
+  return this._conn.requestPost(url, {classids : classids.join(',')}, undefined, callback);
 };
 
 /**
@@ -251,8 +251,8 @@ Tooling.prototype.runTestsAsynchronous = function(classids, callback) {
  * @returns {Promise.<Tooling~ExecuteAnonymousResult>}
  */
 Tooling.prototype.runTestsSynchronous = function(classnames, callback) {
-  var url = this._baseUrl() + "/runTestsSynchronous/?classnames=" + classnames.join(',');
-  return this.request(url).thenCall(callback);
+  var url = this._baseUrl() + "/runTestsSynchronous/";
+  return this._conn.requestPost(url, {classnames : classnames.join(',')}, undefined, callback);
 };
 
 /**


### PR DESCRIPTION
update to address #493 due to SalesForce deprecating the GET method for the runTestsAsynchronous and runTestsSynchronous  tooling API calls.