### PR TITLE
add batchId and jobId to PollingTimeout error object

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -565,6 +565,8 @@ Batch.prototype.poll = function(interval, timeout) {
     if (startTime + timeout < now) {
       var err = new Error("Polling time out. Job Id = " + jobId + " , batch Id = " + batchId);
       err.name = 'PollingTimeout';
+      err.jobId = jobId;
+      err.batchId = batchId;
       self.emit('error', err);
       return;
     }


### PR DESCRIPTION
allows code that is tracking multiple batches to easily determine which batch has timed out