### PR TITLE
Fix repl completion in node v6

### DIFF
--- a/lib/cli/repl.js
+++ b/lib/cli/repl.js
@@ -155,7 +155,7 @@ Repl.prototype.start = function(options) {
 
   this._defineAdditionalCommands(replServer);
 
-  replServer = injectBefore(replServer, "complete", function() {
+  replServer = injectBefore(replServer, "completer", function() {
     self.complete.apply(self, arguments);
   });
   replServer = injectAfter(replServer, "eval", promisify);


### PR DESCRIPTION
REPL completion is not working in node v6 or higher