### PR TITLE
Adding the ability to destroy reports via the analytics API

### DIFF
--- a/lib/api/analytics.js
+++ b/lib/api/analytics.js
@@ -90,6 +90,23 @@ Report.prototype.destroy = function(callback) {
 };
 
 /**
+ * Clones a given report
+ *
+ * @method Analytics~Report#clone
+ * @param {String} name - The name of the new report
+ * @param {Callback.<Analytics~ReportResult>} [callback] - Callback function
+ * @returns {Promise.<Analytics~ReportResult>}
+ */
+Report.prototype.clone = function(name, callback) {
+  var url = [ this._conn._baseUrl(), "analytics", "reports" ].join('/');
+  url += "?cloneId=" + this.id;
+  var data = { reportMetadata: { name: name } };
+  var params = { method : 'POST', url: url, headers: { "Content-Type" : "application/json" }, body: JSON.stringify(data)};
+
+  this._conn.request(params).thenCall(callback);
+};
+
+/**
  * Explain plan for executing report
  *
  * @method Analytics~Report#explain

--- a/lib/api/analytics.js
+++ b/lib/api/analytics.js
@@ -62,6 +62,34 @@ Report.prototype.describe = function(callback) {
 };
 
 /**
+ * Synonym of Analytics~Report#destroy()
+ *
+ * @method Analytics~Report#delete
+ * @param {Callback.<Analytics~ReportResult>} [callback] - Callback function
+ * @returns {Promise.<Analytics~ReportResult>}
+ */
+/**
+ * Synonym of Analytics~Report#destroy()
+ *
+ * @method Analytics~Report#del
+ * @param {Callback.<Analytics~ReportResult>} [callback] - Callback function
+ * @returns {Promise.<Analytics~ReportResult>}
+ */
+/**
+ * Destroy a report
+ *
+ * @method Analytics~Report#destroy
+ * @param {Callback.<Analytics~ReportResult>} [callback] - Callback function
+ * @returns {Promise.<Analytics~ReportResult>}
+ */
+Report.prototype["delete"] =
+Report.prototype.del =
+Report.prototype.destroy = function(callback) {
+  var url = [ this._conn._baseUrl(), "analytics", "reports", this.id ].join('/');
+  return this._conn.request({method: 'DELETE', url: url}).thenCall(callback);
+};
+
+/**
  * Explain plan for executing report
  *
  * @method Analytics~Report#explain

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -18,6 +18,7 @@ describe("analytics", function() {
   var conn = testEnv.createConnection();
 
   var reportId;
+  var cloneId;
 
   /**
    *
@@ -209,6 +210,36 @@ describe("analytics", function() {
           assert.ok(_.isNumber(plan.sobjectCardinality));
           assert.ok(_.isString(plan.sobjectType));
         }
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("clone report", function() {
+    it("should clone the report", function(done) {
+      conn.analytics.report(reportId).clone("Lead List Report Clone", function(err, result) {
+        if (err) { throw err; }
+        assert.ok(_.isObject(result.reportMetadata));
+        cloneId = result.reportMetadata.id;
+        assert.ok(cloneId !== reportId);
+        assert.ok(result.reportMetadata.name === "Lead List Report Clone");
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("destroy report", function() {
+    it("should destroy the report", function(done) {
+      conn.analytics.report(cloneId).destroy(function(err, result) {
+        if (err) { throw err; }
+        conn.analytics.report(cloneId).describe(function(desc_err) {
+          assert.ok(_.isObject(desc_err));
+          assert.ok(desc_err.name === "NOT_FOUND");
+        });
       }.check(done));
     });
   });


### PR DESCRIPTION
I tried to follow as much prior art as possible.  I wasn't sure how to add a test for this so I didn't.  If you have any documentation on writing a test for it I'd be happy to do so.