### PR TITLE
Implement runTests of the Apex SOAP API

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -13,7 +13,7 @@ const commonModules = [
   'inherits', 'util', 'events', 'lodash/core', 'readable-stream', 'multistream'
 ];
 const apiModules = [
-  'analytics', 'apex', 'bulk', 'chatter', 'metadata', 'soap', 'streaming', 'tooling'
+  'analytics', 'apex', 'apexsoap', 'bulk', 'chatter', 'metadata', 'soap', 'streaming', 'tooling'
 ];
 
 const scriptTasks = [{

--- a/lib/api/apexsoap.js
+++ b/lib/api/apexsoap.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var inherits = require('inherits'),
+    jsforce = require('../core'),
+    _       = require('lodash/core'),
+    SOAP    = require('../soap');
+
+/*--------------------------------------------*/
+/**
+ * Class for Salesforce Apexsoap API
+ *
+ * @class
+ * @param {Connection} conn - Connection object
+ */
+var Apexsoap = module.exports = function(conn) {
+  this._conn = conn;
+};
+
+
+/**
+ * Polling interval in milliseconds
+ * @type {Number}
+ */
+Apexsoap.prototype.pollInterval = 1000;
+
+/**
+ * Polling timeout in milliseconds
+ * @type {Number}
+ */
+Apexsoap.prototype.pollTimeout = 10000;
+
+
+/**
+ * Call Apexsoap API SOAP endpoint
+ *
+ * @private
+ */
+Apexsoap.prototype._invoke = function(method, message, callback) {
+  var soapEndpoint = new SOAP(this._conn, {
+    xmlns: "http://soap.sforce.com/2006/08/apex",
+    endpointUrl: this._conn.instanceUrl + "/services/Soap/s/" + this._conn.version
+  });
+  return soapEndpoint.invoke(method, message).then(function(res) {
+    return res.result;
+  }).thenCall(callback);
+};
+
+/**
+ * Synchronously runTests specified Apexsoap components in the organization.
+ *
+ * @method Apexsoap#runTests
+ * @param {Apexsoap~RunTestsRequest|Array.<Apexsoap~RunTestsRequest>} RunTestsRequest - full name(s) of Apexsoap objects to runTests
+ * @param {Callback.<Apexsoap~RunTestResult|Array.<Apexsoap~RunTestResult>>} [callback] - Callback function
+ * @returns {Promise.<Array.<Apexsoap~RunTestResult|Array.<Apexsoap~RunTestResult>>>}
+ */
+Apexsoap.prototype.runTests = function(RunTestsRequest, callback) {
+  return this._invoke("runTests", { RunTestsRequest: RunTestsRequest }).then(function(results) {
+    return convertToRunTestResult(results);
+  }).thenCall(callback);
+};
+
+/**
+ * @typedef {Object} Apexsoap~RunTestResult
+ */
+
+/**
+ * @private
+ */
+function convertToRunTestResult(result) {
+  var runTestResult = _.clone(result);
+  if (runTestResult.codeCoverage) {
+    runTestResult.codeCoverage = runTestResult.codeCoverage;
+    if(!_.isArray(runTestResult.codeCoverage)) {
+      runTestResult.codeCoverage = [runTestResult.codeCoverage];
+    }
+  }
+  if (runTestResult.codeCoverageWarnings) {
+    runTestResult.codeCoverageWarnings = runTestResult.codeCoverageWarnings;
+    if(!_.isArray(runTestResult.codeCoverageWarnings)) {
+      runTestResult.codeCoverageWarnings = [runTestResult.codeCoverageWarnings];
+    }
+  }
+  if (runTestResult.failures) {
+    runTestResult.failures = runTestResult.failures;
+    if(!_.isArray(runTestResult.failures)) {
+      runTestResult.failures = [runTestResult.failures];
+    }
+  }
+  runTestResult.numFailures = Number(runTestResult.numFailures);
+  runTestResult.numTestsRun = Number(runTestResult.numTestsRun);
+  if (runTestResult.successes) {
+    runTestResult.successes = runTestResult.successes;
+    if(!_.isArray(runTestResult.successes)) {
+      runTestResult.successes = [runTestResult.successes];
+    }
+  }
+  runTestResult.totalTime = Number(runTestResult.totalTime);
+
+  return runTestResult;
+}
+
+/*--------------------------------------------*/
+/*
+ * Register hook in connection instantiation for dynamically adding this API module features
+ */
+jsforce.on('connection:new', function(conn) {
+  conn.apexsoap = new Apexsoap(conn);
+});

--- a/lib/api/apexsoap.js
+++ b/lib/api/apexsoap.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var inherits = require('inherits'),
-    jsforce = require('../core'),
+var jsforce = require('../core'),
     _       = require('lodash/core'),
     SOAP    = require('../soap');
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,5 +1,6 @@
 require('./analytics');
 require('./apex');
+require('./apexsoap');
 require('./bulk');
 require('./chatter');
 require('./metadata');

--- a/test/apexsoap.test.js
+++ b/test/apexsoap.test.js
@@ -2,10 +2,7 @@
 var TestEnv = require('./helper/testenv'),
     assert = TestEnv.assert;
 
-var async  = require('async'),
-    _      = require('lodash/core'),
-    sf     = require('../lib/jsforce'),
-    config = require('./config/salesforce');
+var config = require('./config/salesforce');
 
 var testEnv = new TestEnv(config);
 
@@ -25,8 +22,6 @@ describe("apexsoap", function() {
     this.timeout(600000); // set timeout to 10 min.
     testEnv.establishConnection(conn, done);
   });
-
-  var accountId;
 
   /**
    *

--- a/test/apexsoap.test.js
+++ b/test/apexsoap.test.js
@@ -1,0 +1,58 @@
+/*global describe, it, before, after */
+var TestEnv = require('./helper/testenv'),
+    assert = TestEnv.assert;
+
+var async  = require('async'),
+    _      = require('lodash/core'),
+    sf     = require('../lib/jsforce'),
+    config = require('./config/salesforce');
+
+var testEnv = new TestEnv(config);
+
+/**
+ *
+ */
+describe("apexsoap", function() {
+
+  this.timeout(40000); // set timeout to 40 sec.
+
+  var conn = testEnv.createConnection();
+
+  /**
+   *
+   */
+  before(function(done) {
+    this.timeout(600000); // set timeout to 10 min.
+    testEnv.establishConnection(conn, done);
+  });
+
+  var accountId;
+
+  /**
+   *
+   */
+  describe("run tests synchronous", function() {
+    it("should execute one unit test and run successfully", function(done) {
+      var params = {
+        allTests: false,
+        classes: [
+          'JSforceTestUnitTest'
+        ]
+      };
+      conn.apexsoap.runTests(params, function(err, results) {
+        if (err) { throw err; }
+        assert.ok(0 === results.numFailures);
+        assert.ok(1 === results.numTestsRun);
+      }.check(done));
+    });
+  });
+
+ 
+  /**
+   *
+   */
+  after(function(done) {
+    testEnv.closeConnection(conn, done);
+  });
+
+});

--- a/test/bin/org-setup
+++ b/test/bin/org-setup
@@ -14,7 +14,7 @@ var conn = new jsforce.Connection({ logLevel: process.env.DEBUG });
 conn.login(process.env.SF_USERNAME, process.env.SF_PASSWORD)
   .then(function() {
     console.log('Deploying test suite package...');
-    conn.metadata.pollTimeout = 60*1000;
+    conn.metadata.pollTimeout = 10*60*1000;
     return conn.metadata.deploy(archive).complete(true);
   })
   .then(function(res) {

--- a/test/package/JSforceTestSuite/classes/JSforceTestUnitTest.cls
+++ b/test/package/JSforceTestSuite/classes/JSforceTestUnitTest.cls
@@ -1,0 +1,7 @@
+@isTest
+public class JSforceTestUnitTest {
+
+    public static testMethod void dummyTest() {
+        System.assert(true);
+    }
+}

--- a/test/package/JSforceTestSuite/classes/JSforceTestUnitTest.cls-meta.xml
+++ b/test/package/JSforceTestSuite/classes/JSforceTestUnitTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/package/JSforceTestSuite/package.xml
+++ b/test/package/JSforceTestSuite/package.xml
@@ -4,6 +4,7 @@
         <members>JSforceTestApexRest</members>
         <members>JSforceTestData</members>
         <members>JSforceTestDataCleaningScheduler</members>
+        <members>JSforceTestUnitTest</members>
         <members>JSforceTestUserPool</members>
         <members>JSforceTestUtil</members>
         <name>ApexClass</name>


### PR DESCRIPTION
Resolve https://github.com/jsforce/jsforce/issues/565

@stomita I think `apex` shall have been called something like `apexrest` and what I have now called `apexsoap` as `apex`. But to avoid too much changes, we may want to keep it like this the time being.