### PR TITLE
Test improvements & doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ See [license](LICENSE) (MIT License).
 
 If you have any questions first file it on [issues](https://github.com/jsforce/jsforce/issues) before contacting authors via e-mail.
 
+## Tests
+
+In order to run tests you will need:
+- [PhantomJS](http://phantomjs.org)
+- [Salesforce Developer Org](https://developer.salesforce.com/signup)
+
+You will also need to install the JsforceTestSuite package, which can be done by running:
+
+    SF_USERNAME=myusername SF_PASSWORD=password+securityToken ./test/bin/org-setup
+
+/You may need to run this more then once if you encounter timeouts or dropped connections/
+
+Finally, to run the tests simply do:
+
+    SF_USERNAME=myusername SF_PASSWORD=password+securityToken npm run test:node
+
+    SF_USERNAME=myusername SF_PASSWORD=password+securityToken npm run test:browser
+
 ## Contributions
 
 Your contributions are welcome: both by reporting issues on [GitHub issues](https://github.com/jsforce/jsforce/issues) or pull-requesting patches.

--- a/test/bin/run-test
+++ b/test/bin/run-test
@@ -19,7 +19,7 @@ setTimeout(function() {
     args.push("test/" + process.argv[2]+ ".test.js");
   }
 
-  var mocha = spawn('mocha', args);
+  var mocha = spawn(__dirname + '/../../node_modules/.bin/mocha', args);
 
   mocha.stdout.pipe(process.stdout);
   mocha.stderr.pipe(process.stderr);

--- a/test/package/JSforceTestSuite/permissionsets/JSforceTestPowerUser.permissionset
+++ b/test/package/JSforceTestSuite/permissionsets/JSforceTestPowerUser.permissionset
@@ -131,6 +131,10 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
+        <name>DelegatedTwoFactor</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
         <name>DeleteTopics</name>
     </userPermissions>
     <userPermissions>


### PR DESCRIPTION
This PR:
- Adds a permission set needed to deploy the package for new developer orgs (DelegatedTwoFactor), without this the package deploy will fail on a fresh ```org-setup```.
- Adds a section to the ```README``` about how to run the tests.
- Makes the call to mocha in ```run-test``` absolute so that if you run it directly it will work, whereas right now it only works when run through ```npm test```.
