### PR TITLE
JSONP Transport 'supported' also checks for document

### DIFF
--- a/lib/browser/jsonp.js
+++ b/lib/browser/jsonp.js
@@ -5,7 +5,7 @@ var _index = 0;
 
 module.exports = {
 
-  supported: typeof window !== 'undefined',
+  supported: typeof window !== 'undefined' && typeof document !== undefined,
 
   createRequest: function(jsonpParam, timeout) {
     jsonpParam = jsonpParam || 'callback';

--- a/lib/browser/jsonp.js
+++ b/lib/browser/jsonp.js
@@ -5,7 +5,7 @@ var _index = 0;
 
 module.exports = {
 
-  supported: typeof window !== 'undefined' && typeof document !== undefined,
+  supported: typeof window !== 'undefined' && typeof document !== 'undefined',
 
   createRequest: function(jsonpParam, timeout) {
     jsonpParam = jsonpParam || 'callback';


### PR DESCRIPTION
In an environment such as React Native the ```window``` object is defined, but the ```document``` object is not, making the JSONP support not function correctly.  This PR adds a check to ```document``` as well. There shouldn't be any regressions from this change.