### PR TITLE
Remove support of Node.js 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 matrix:
   include:
-    - node_js: "0.12"
+    - node_js: "4"
       env: BROWSER_TEST=false
-    - node_js: "4.2"
+    - node_js: "6"
       env: BROWSER_TEST=false
     - node_js: "stable"
       env: BROWSER_TEST=false

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4.0"
   },
   "bin": {
     "jsforce": "./bin/jsforce"


### PR DESCRIPTION
As 0.12 maintenance will end in the end of 2016, remove the support of 0.12 in JSforce.