### PR TITLE
Allow the ability to programmatically specify a proxy when using the library in node.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,7 +43,8 @@ var defaults = {
  * @param {String} [options.sessionId] - Salesforce session ID
  * @param {String} [options.refreshToken] - Salesforce OAuth2 refresh token
  * @param {String|Object} [options.signedRequest] - Salesforce Canvas signed request (Raw Base64 string, JSON string, or deserialized JSON)
- * @param {String} [options.proxyUrl] - In browser client, cross-domain proxy server URL, non Visualforce app; when in node, a proxy server URL
+ * @param {String} [options.proxyUrl] - Cross-domain proxy server URL, used in browser client, non Visualforce app.
+ * @param {String} [options.proxy] - URL of proxy server, used in server client.
  * @param {Object} [options.callOptions] - Call options used in each SOAP/REST API request. See manual.
  */
 var Connection = module.exports = function(options) {
@@ -56,7 +57,8 @@ var Connection = module.exports = function(options) {
     clientId : options.clientId,
     clientSecret : options.clientSecret,
     redirectUri : options.redirectUri,
-    proxyUrl: options.proxyUrl
+    proxyUrl: options.proxyUrl,
+    proxy: options.proxy
   };
 
   /**
@@ -70,8 +72,13 @@ var Connection = module.exports = function(options) {
   this.maxRequest = options.maxRequest || this.maxRequest || 10;
 
   /** @private */
-  this._transport =
-    options.proxyUrl ? new Transport.ProxyTransport(options.proxyUrl) : new Transport();
+  if (options.proxyUrl) {
+    this._transport = new Transport.ProxyTransport(options.proxyUrl);
+  } else if (options.proxy) {
+    this._transport = new Transport.ProxyServerTransport(options.proxy);
+  } else {
+    this._transport = new Transport();
+  }
 
   this.callOptions = options.callOptions;
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,7 +43,7 @@ var defaults = {
  * @param {String} [options.sessionId] - Salesforce session ID
  * @param {String} [options.refreshToken] - Salesforce OAuth2 refresh token
  * @param {String|Object} [options.signedRequest] - Salesforce Canvas signed request (Raw Base64 string, JSON string, or deserialized JSON)
- * @param {String} [options.proxyUrl] - Cross-domain proxy server URL, used in browser client, non Visualforce app.
+ * @param {String} [options.proxyUrl] - In browser client, cross-domain proxy server URL, non Visualforce app; when in node, a proxy server URL
  * @param {Object} [options.callOptions] - Call options used in each SOAP/REST API request. See manual.
  */
 var Connection = module.exports = function(options) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -44,7 +44,7 @@ var defaults = {
  * @param {String} [options.refreshToken] - Salesforce OAuth2 refresh token
  * @param {String|Object} [options.signedRequest] - Salesforce Canvas signed request (Raw Base64 string, JSON string, or deserialized JSON)
  * @param {String} [options.proxyUrl] - Cross-domain proxy server URL, used in browser client, non Visualforce app.
- * @param {String} [options.proxy] - URL of proxy server, used in server client.
+ * @param {String} [options.httpProxy] - URL of HTTP proxy server, used in server client.
  * @param {Object} [options.callOptions] - Call options used in each SOAP/REST API request. See manual.
  */
 var Connection = module.exports = function(options) {
@@ -58,7 +58,7 @@ var Connection = module.exports = function(options) {
     clientSecret : options.clientSecret,
     redirectUri : options.redirectUri,
     proxyUrl: options.proxyUrl,
-    proxy: options.proxy
+    httpProxy: options.httpProxy
   };
 
   /**
@@ -74,8 +74,8 @@ var Connection = module.exports = function(options) {
   /** @private */
   if (options.proxyUrl) {
     this._transport = new Transport.ProxyTransport(options.proxyUrl);
-  } else if (options.proxy) {
-    this._transport = new Transport.ProxyServerTransport(options.proxy);
+  } else if (options.httpProxy) {
+    this._transport = new Transport.HttpProxyTransport(options.httpProxy);
   } else {
     this._transport = new Transport();
   }

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -41,8 +41,13 @@ var OAuth2 = module.exports = function(options) {
   this.clientId = options.clientId;
   this.clientSecret = options.clientSecret;
   this.redirectUri = options.redirectUri;
-  this._transport =
-    options.proxyUrl ? new Transport.ProxyTransport(options.proxyUrl) : new Transport();
+  if (options.proxyUrl) {
+    this._transport = new Transport.ProxyTransport(options.proxyUrl);
+  } else if (options.proxy) {
+    this._transport = new Transport.ProxyServerTransport(options.proxy);
+  } else {
+    this._transport = new Transport();
+  }
 };
 
 

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -43,8 +43,8 @@ var OAuth2 = module.exports = function(options) {
   this.redirectUri = options.redirectUri;
   if (options.proxyUrl) {
     this._transport = new Transport.ProxyTransport(options.proxyUrl);
-  } else if (options.proxy) {
-    this._transport = new Transport.ProxyServerTransport(options.proxy);
+  } else if (options.httpProxy) {
+    this._transport = new Transport.HttpProxyTransport(options.httpProxy);
   } else {
     this._transport = new Transport();
   }

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -191,26 +191,26 @@ ProxyTransport.prototype.httpRequest = function(params, callback) {
 /**
  * Class for HTTP request transport using a proxy server
  *
- * @class Transport~ProxyServerTransport
+ * @class Transport~HttpProxyTransport
  * @protected
  * @extends Transport
- * @param {String} proxy - URL of the proxy server
+ * @param {String} httpProxy - URL of the HTTP proxy server
  */
-var ProxyServerTransport = Transport.ProxyServerTransport = function(proxy) {
-  this._proxy = proxy;
+var HttpProxyTransport = Transport.HttpProxyTransport = function(httpProxy) {
+  this._httpProxy = httpProxy;
 };
 
-inherits(ProxyServerTransport, Transport);
+inherits(HttpProxyTransport, Transport);
 
 /**
  * Make HTTP request via proxy server
  *
- * @method Transport~ProxyServerTransport#httpRequest
+ * @method Transport~HttpProxyTransport#httpRequest
  * @param {Object} params - HTTP request
  * @param {Callback.<Object>} [callback] - Callback Function
  * @returns {Promise.<Object>}
  */
-ProxyServerTransport.prototype.httpRequest = function(params, callback) {
+HttpProxyTransport.prototype.httpRequest = function(params, callback) {
   var url = params.url;
   if (url.indexOf("/") === 0) {
     url = baseUrl + url;
@@ -218,7 +218,7 @@ ProxyServerTransport.prototype.httpRequest = function(params, callback) {
   var proxyParams = {
     method: params.method,
     url: params.url,
-    proxy: this._proxy,
+    proxy: this._httpProxy,
     headers: {}
   };
   if (params.body || params.body === "") {
@@ -229,5 +229,5 @@ ProxyServerTransport.prototype.httpRequest = function(params, callback) {
       proxyParams.headers[name] = params.headers[name];
     }
   }
-  return ProxyServerTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
+  return HttpProxyTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
 };

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -143,12 +143,12 @@ CanvasTransport.supported = canvas.supported;
 
 
 /**
- * Class for HTTP request transport using proxy service
+ * Class for HTTP request transport using AJAX proxy service
  *
  * @class Transport~ProxyTransport
  * @protected
  * @extends Transport
- * @param {String} proxyUrl - Proxy server URL
+ * @param {String} proxyUrl - AJAX Proxy server URL
  */
 var ProxyTransport = Transport.ProxyTransport = function(proxyUrl) {
   this._proxyUrl = proxyUrl;
@@ -157,11 +157,11 @@ var ProxyTransport = Transport.ProxyTransport = function(proxyUrl) {
 inherits(ProxyTransport, Transport);
 
 /**
- * Make HTTP request via proxy
+ * Make HTTP request via AJAX proxy
  *
  * @method Transport~ProxyTransport#httpRequest
  * @param {Object} params - HTTP request
- * @param {Callback.<Object>} [callback] - Callback Function
+ * @param {Callback.<Object>} [callback] - Calback Function
  * @returns {Promise.<Object>}
  */
 ProxyTransport.prototype.httpRequest = function(params, callback) {
@@ -170,18 +170,12 @@ ProxyTransport.prototype.httpRequest = function(params, callback) {
     url = baseUrl + url;
   }
   var proxyParams = {
-    method: params.method
-  };
-  if (typeof window === 'undefined') {
-    proxyParams.url = url;
-    proxyParams.proxy = this._proxyUrl;
-    proxyParams.headers = {};
-  } else {
-    proxyParams.url = this._proxyUrl + '?' + Date.now() + "." + ("" + Math.random()).substring(2);
-    proxyParams.headers = {
+    method: params.method,
+    url: this._proxyUrl + '?' + Date.now() + "." + ("" + Math.random()).substring(2),
+    headers: {
       'salesforceproxy-endpoint': url
-    };
-  }
+    }
+  };
   if (params.body || params.body === "") {
     proxyParams.body = params.body;
   }
@@ -191,4 +185,49 @@ ProxyTransport.prototype.httpRequest = function(params, callback) {
     }
   }
   return ProxyTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
+};
+
+
+/**
+ * Class for HTTP request transport using a proxy server
+ *
+ * @class Transport~ProxyServerTransport
+ * @protected
+ * @extends Transport
+ * @param {String} proxy - URL of the proxy server
+ */
+var ProxyServerTransport = Transport.ProxyServerTransport = function(proxy) {
+  this._proxy = proxy;
+};
+
+inherits(ProxyServerTransport, Transport);
+
+/**
+ * Make HTTP request via proxy server
+ *
+ * @method Transport~ProxyServerTransport#httpRequest
+ * @param {Object} params - HTTP request
+ * @param {Callback.<Object>} [callback] - Callback Function
+ * @returns {Promise.<Object>}
+ */
+ProxyServerTransport.prototype.httpRequest = function(params, callback) {
+  var url = params.url;
+  if (url.indexOf("/") === 0) {
+    url = baseUrl + url;
+  }
+  var proxyParams = {
+    method: params.method,
+    url: params.url,
+    proxy: this._proxy,
+    headers: {}
+  };
+  if (params.body || params.body === "") {
+    proxyParams.body = params.body;
+  }
+  if (params.headers) {
+    for (var name in params.headers) {
+      proxyParams.headers[name] = params.headers[name];
+    }
+  }
+  return ProxyServerTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
 };

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -143,12 +143,12 @@ CanvasTransport.supported = canvas.supported;
 
 
 /**
- * Class for HTTP request transport using AJAX proxy service
+ * Class for HTTP request transport using proxy service
  *
  * @class Transport~ProxyTransport
  * @protected
  * @extends Transport
- * @param {String} proxyUrl - AJAX Proxy server URL
+ * @param {String} proxyUrl - Proxy server URL
  */
 var ProxyTransport = Transport.ProxyTransport = function(proxyUrl) {
   this._proxyUrl = proxyUrl;
@@ -157,11 +157,11 @@ var ProxyTransport = Transport.ProxyTransport = function(proxyUrl) {
 inherits(ProxyTransport, Transport);
 
 /**
- * Make HTTP request via AJAX proxy
+ * Make HTTP request via proxy
  *
  * @method Transport~ProxyTransport#httpRequest
  * @param {Object} params - HTTP request
- * @param {Callback.<Object>} [callback] - Calback Function
+ * @param {Callback.<Object>} [callback] - Callback Function
  * @returns {Promise.<Object>}
  */
 ProxyTransport.prototype.httpRequest = function(params, callback) {
@@ -170,12 +170,18 @@ ProxyTransport.prototype.httpRequest = function(params, callback) {
     url = baseUrl + url;
   }
   var proxyParams = {
-    method: params.method,
-    url: this._proxyUrl + '?' + Date.now() + "." + ("" + Math.random()).substring(2),
-    headers: {
-      'salesforceproxy-endpoint': url
-    }
+    method: params.method
   };
+  if (typeof window === 'undefined') {
+    proxyParams.url = url;
+    proxyParams.proxy = this._proxyUrl;
+    proxyParams.headers = {};
+  } else {
+    proxyParams.url = this._proxyUrl + '?' + Date.now() + "." + ("" + Math.random()).substring(2);
+    proxyParams.headers = {
+      'salesforceproxy-endpoint': url
+    };
+  }
   if (params.body || params.body === "") {
     proxyParams.body = params.body;
   }


### PR DESCRIPTION
This implements the ability to specify a proxy programmatically when using jsforce on the server as a node module. This pull request piggybacks on the `proxyUrl` parameter and passes it through to the `request` module's `proxy` parameter. This also provides a fix for jsforce/jsforce#1.

The issue for us with using the `HTTP_PROXY` environment variable is that then all outgoing requests (at least using the `request` library) would be forced to use the proxy. This is because the `request` library also respects the `HTTP_PROXY` environment variable (https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables). In our use case, we want to force all jsforce requests to go through a proxy but we don't necessarily want all other requests in that same node process to use the proxy.

Usage (as in jsforce/jsforce#1):
```
var jsforce = require('jsforce');
var conn = new jsforce.Connection({
    proxy: 'http://proxy_url:port'
});
```