### PR TITLE
External Id should not be mandatory on upsert

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -746,9 +746,6 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
     _.map(records, function(record) {
       var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
       var extId = record[extIdField];
-      if (!extId) {
-        return Promise.reject(new Error('External ID is not defined in the record'));
-      }
       record = _.clone(record);
       delete record[extIdField];
       delete record.type;


### PR DESCRIPTION
Apex/Bulk API can use the Id field as an external Id. In those cases, you can't provide a value, and thus it fails with JSForce due to this error condition. Also, (although it's not a good idea in my opinion), you could have a blank value as an External Id.