### PR TITLE
Update http-api.js

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -282,7 +282,7 @@ SessionRefreshDelegate.prototype.refresh = function(since, callback) {
   self._refreshing = true;
   return self._refreshFn(conn, function(err, accessToken, res) {
     if (!err) {
-      logger.debug("Connection refresh completed. Refreshed access token = " + accessToken);
+      logger.debug("Connection refresh completed.);
       conn.accessToken = accessToken;
       conn.emit("refresh", accessToken, res);
     }


### PR DESCRIPTION
Removed access token from log files. Users can send log files across the internet in plain text. This log line will give a malicious user access to a salesforce instance.