### PR TITLE
Update http-api.js

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -282,7 +282,7 @@ SessionRefreshDelegate.prototype.refresh = function(since, callback) {
   self._refreshing = true;
   return self._refreshFn(conn, function(err, accessToken, res) {
     if (!err) {
-      logger.debug("Connection refresh completed. Refreshed access token = " + accessToken);
+      logger.debug("Connection refresh completed.");
       conn.accessToken = accessToken;
       conn.emit("refresh", accessToken, res);
     }


### PR DESCRIPTION
Users frequently send log file over the internet in plain text. We are hoping all code reviews will not allow jsforce merges that contain writing out salesforce access and refresh tokens to log files in plain text.