### PR TITLE
add  DuplicateRuleHeader with SOAP API

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -191,6 +191,9 @@ SOAP.prototype._createEnvelope = function(message) {
   if (conn.callOptions) {
     header.CallOptions = conn.callOptions;
   }
+  if (conn.duplicateRuleHeader) {
+    header.DuplicateRuleHeader = conn.duplicateRuleHeader;
+  }
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"',


### PR DESCRIPTION
Sometimes we want to insert records, without duplicate rules errors.
we added DuplicateRuleHeader with SOAP API .