### PR TITLE
Fix Bug Limiting Number of Records RecordStream.Parsable Can Handle

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -34,7 +34,6 @@ inherits(RecordStream, Transform);
  */
 RecordStream.prototype._transform = function(record, enc, callback) {
   this.emit('record', record);
-  this.push(record);
   callback();
 };
 
@@ -119,7 +118,7 @@ Parsable.prototype.stream = function(type, options) {
   if (!this._dataStream) {
     this._dataStream = new PassThrough();
     this._parserStream = converter.parse(options);
-    this._parserStream.pipe(this).pipe(new PassThrough({ objectMode: true, highWaterMark: ( 500 * 1000 ) }));
+    this._parserStream.pipe(this).pipe(new PassThrough({ objectMode: true }));
   }
   return this._dataStream;
 };


### PR DESCRIPTION
More details in the issue I filed here: https://github.com/jsforce/jsforce/issues/697

This change removes the call to this.push(record) in the _transform method of RecordStream, which causes some buffer that isn't getting read to overflow after 1,000,016 pushes, which manifests itself such that anyone using Bulk.query() to fetch more than 1M16 records has their stream cut off prematurely.

I have also removed the highWaterMark setting later on, as I found it was unnecessary once I removed the call to this.push() above, which caused me to assume that overriding the default there was a workaround for the bug in _transform, and it simply took a long time for anyone to exceed the limit of the workaround that was in place.