### PR TITLE
Add PKChunking option in Bulk operation

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -104,13 +104,26 @@ Job.prototype.open = function(callback) {
       '</jobInfo>'
     ].join('');
 
+    var headers = {
+      'Content-Type' : 'application/xml; charset=utf-8'
+    };
+    var pkChunking = this.options.pkChunking;
+    if(pkChunking) {
+      var chunkingParams = Object.keys(pkChunking)
+      .filter(function(key) {
+         return ['chunkSize', 'parent', 'startRow'].indexOf(key) >= 0;
+      })
+      .map(function(key) {
+         return key + '=' + pkChunking[key];
+      });
+      if(chunkingParams.length)
+        headers['Sforce-Enable-PKChunking'] = chunkingParams.join('; ');
+    }    
     this._jobInfo = bulk._request({
       method : 'POST',
       path : "/job",
       body : body,
-      headers : {
-        "Content-Type" : "application/xml; charset=utf-8"
-      },
+      headers : headers,
       responseType: "application/xml"
     }).then(function(res) {
       self.emit("open", res.jobInfo);


### PR DESCRIPTION
Added PKChunking option in bulk operations. The parameters chunkSize, parent and startRow are supported.

Ex:
let job = conn.bulk.createJob('Account', 'query', {
    pkChunking: {
      chunkSize: 250000,
    }
});

See: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/async_api_headers_enable_pk_chunking.htm