### PR TITLE
Updating browser client to use js-cookie

### DIFF
--- a/lib/browser/client.js
+++ b/lib/browser/client.js
@@ -10,7 +10,8 @@ var events = require('events'),
     qs = require('querystring'),
     _ = require('lodash/core'),
     Connection = require('../connection'),
-    OAuth2 = require('../oauth2');
+    OAuth2 = require('../oauth2'),
+    jsCookie = require('js-cookie');
 
 /**
  * @private
@@ -173,8 +174,7 @@ Client.prototype.logout = function() {
  * @private
  */
 Client.prototype._getTokens = function() {
-  var regexp = new RegExp("(^|;\\s*)"+this._prefix+"_loggedin=true(;|$)");
-  if (document.cookie.match(regexp)) {
+  if (jsCookie.get(this._prefix + '_loggedin') == 'true') {
     var issuedAt = Number(localStorage.getItem(this._prefix+'_issued_at'));
     if (Date.now() < issuedAt + 2 * 60 * 60 * 1000) { // 2 hours
       var userInfo;
@@ -201,7 +201,7 @@ Client.prototype._storeTokens = function(params) {
   localStorage.setItem(this._prefix + '_instance_url', params.instance_url);
   localStorage.setItem(this._prefix + '_issued_at', params.issued_at);
   localStorage.setItem(this._prefix + '_id', params.id);
-  document.cookie = this._prefix + '_loggedin=true;';
+  jsCookie.set(this._prefix + '_loggedin', true);
 };
 
 /**
@@ -212,7 +212,7 @@ Client.prototype._removeTokens = function() {
   localStorage.removeItem(this._prefix + '_instance_url');
   localStorage.removeItem(this._prefix + '_issued_at');
   localStorage.removeItem(this._prefix + '_id');
-  document.cookie = this._prefix + '_loggedin=';
+  jsCookie.remove(this._prefix + '_loggedin');
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "csv-stringify": "^1.0.4",
     "faye": "^1.2.0",
     "inherits": "^2.0.1",
+    "js-cookie": "^2.2.0",
     "lodash": "^4.11.1",
     "multistream": "^2.0.5",
     "open": "0.0.5",


### PR DESCRIPTION
Setting document.cookie in the popup window is flaky for me in current chrome on OSX.

When I call `jsforce.browser.login` it runs [`removeTokens`](https://github.com/jsforce/jsforce/blob/master/lib/browser/client.js#L133) which [unsets the cookie](https://github.com/jsforce/jsforce/blob/master/lib/browser/client.js#L215). It then sets the cookie on successful login within the popup window. I then refresh the opener and the value is still blank. I noticed after [setting the cookie=true](https://github.com/jsforce/jsforce/blob/master/lib/browser/client.js#L204) in the popup it contains the same key twice in the developer console. Using js-cookie resolves this issue for me.