### PR TITLE
Accept code challenge and verifier in requesting authorization and request token

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -946,14 +946,20 @@ Connection.prototype.identity = function(options, callback) {
  * Authorize (using oauth2 web server flow)
  *
  * @param {String} code - Authorization code
+ * @param {Object} [params] - Optional parameters to send in token retrieval
+ * @param {String} [params.code_verifier] - Code verifier value (RFC 7636 - Proof Key of Code Exchange)
  * @param {Callback.<UserInfo>} [callback] - Callback function
  * @returns {Promise.<UserInfo>}
  */
-Connection.prototype.authorize = function(code, callback) {
+Connection.prototype.authorize = function(code, params, callback) {
+  if (typeof params === 'function') {
+    callback = params;
+    params = {};
+  }
   var self = this;
   var logger = this._logger;
 
-  return this.oauth2.requestToken(code).then(function(res) {
+  return this.oauth2.requestToken(code, params).then(function(res) {
     var userInfo = parseIdUrl(res.id);
     self.initialize({
       instanceUrl : res.instance_url,

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -23,7 +23,7 @@ var defaults = {
  * @param {String} [options.authzServiceUrl] - OAuth2 authorization service URL. If not specified, it generates from default by adding to login server URL.
  * @param {String} [options.tokenServiceUrl] - OAuth2 token service URL. If not specified it generates from default by adding to login server URL.
  * @param {String} options.clientId - OAuth2 client ID.
- * @param {String} options.clientSecret - OAuth2 client secret.
+ * @param {String} [options.clientSecret] - OAuth2 client secret (This is optional for public client).
  * @param {String} options.redirectUri - URI to be callbacked from Salesforce OAuth2 authorization service.
  */
 var OAuth2 = module.exports = function(options) {
@@ -61,8 +61,9 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
    * Get Salesforce OAuth2 authorization page URL to redirect user agent.
    *
    * @param {Object} params - Parameters
-   * @param {String} params.scope - Scope values in space-separated string
-   * @param {String} params.state - State parameter
+   * @param {String} [params.scope] - Scope values in space-separated string
+   * @param {String} [params.state] - State parameter
+   * @param {String} [params.code_challenge] - Code challenge value (RFC 7636 - Proof Key of Code Exchange)
    * @returns {String} Authorization page URL
    */
   getAuthorizationUrl : function(params) {
@@ -91,12 +92,15 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
    * @returns {Promise.<TokenResponse>}
    */
   refreshToken : function(refreshToken, callback) {
-    return this._postParams({
+    var params = {
       grant_type : "refresh_token",
       refresh_token : refreshToken,
       client_id : this.clientId,
-      client_secret : this.clientSecret
-    }, callback);
+    };
+    if (this.clientSecret) {
+      params.client_secret = this.clientSecret;
+    }
+    return this._postParams(params, callback);
   },
 
   /**
@@ -104,17 +108,25 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
    * Access Token Request
    *
    * @param {String} code - Authorization code
+   * @param {Object} [params] - Optional parameters to send in token retrieval
+   * @param {String} [params.code_verifier] - Code verifier value (RFC 7636 - Proof Key of Code Exchange)
    * @param {Callback.<TokenResponse>} [callback] - Callback function
    * @returns {Promise.<TokenResponse>}
    */
-  requestToken : function(code, callback) {
-    return this._postParams({
+  requestToken : function(code, params, callback) {
+    if (typeof params === 'function') {
+      callback = params;
+      params = {};
+    }
+    params = _.extend({
       grant_type : "authorization_code",
       code : code,
       client_id : this.clientId,
-      client_secret : this.clientSecret,
-      redirect_uri : this.redirectUri
-    }, callback);
+    }, params || {});
+    if (this.clientSecret) {
+      params.client_secret = this.clientSecret;
+    }
+    return this._postParams(params, callback);
   },
 
   /**

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -95,7 +95,7 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
     var params = {
       grant_type : "refresh_token",
       refresh_token : refreshToken,
-      client_id : this.clientId,
+      client_id : this.clientId
     };
     if (this.clientSecret) {
       params.client_secret = this.clientSecret;
@@ -122,6 +122,7 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
       grant_type : "authorization_code",
       code : code,
       client_id : this.clientId,
+      redirect_uri : this.redirectUri
     }, params || {});
     if (this.clientSecret) {
       params.client_secret = this.clientSecret;


### PR DESCRIPTION
In order to support public client,
- make client secret to optional in token request
- add code challenge params in authorization request / code verifier params in token request