### PR TITLE
Remove client secret check to accept refresh token

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -145,7 +145,7 @@ var Connection = module.exports = function(options) {
   // Allow to delegate connection refresh to outer function
   var self = this;
   var refreshFn = options.refreshFn;
-  if (!refreshFn && this.oauth2.clientId && this.oauth2.clientSecret) {
+  if (!refreshFn && this.oauth2.clientId) {
     refreshFn = oauthRefreshFn;
   }
   if (refreshFn) {


### PR DESCRIPTION
As the refresh flow does not always need the oauth2 client secret in former enhancement (#735), it should be removed to work the refresh flow completely.