### PR TITLE
Streaming API extensions, replay extension, & auth failure detection

### DIFF
--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -192,6 +192,91 @@ Streaming.prototype.unsubscribe = function(name, listener) {
   return this;
 };
 
+/**
+ * Auth failure detector extension
+ *
+ * Based on new feature released with Salesforce Spring '18:
+ * https://releasenotes.docs.salesforce.com/en-us/spring18/release-notes/rn_messaging_cometd_auth_validation.htm?edition=&impact=
+ *
+ * Actual error message:
+ * {
+ *   "ext":{
+ *     "sfdc":{"failureReason":"401::Authentication invalid"},
+ *     "replay":true},
+ *   "advice":{"reconnect":"none"},
+ *   "channel":"/meta/handshake",
+ *   "error":"403::Handshake denied",
+ *   "successful":false
+ * }
+ *
+ * @param {Function} failureCallback - Invoked when authentication becomes invalid
+ */
+Streaming.authFailureExtension = function(failureCallback) {
+  this.incoming = function(message, callback) {
+    if (
+      (message.channel === '/meta/connect' ||
+        message.channel === '/meta/handshake')
+      && message.advice
+      && message.advice.reconnect == 'none'
+    ) {
+      failureCallback(message);
+    } else {
+      callback(message);
+    }
+  }
+};
+
+/**
+ * Durable streaming replay extension
+ *
+ * Modified from original Salesforce demo source code:
+ * https://github.com/developerforce/SalesforceDurableStreamingDemo/blob/3d4a56eac956f744ad6c22e6a8141b6feb57abb9/staticresources/cometdReplayExtension.resource
+ */
+Streaming.cometdReplayExtension = function() {
+  var REPLAY_FROM_KEY = "replay";
+  
+  var _extensionEnabled;
+  var _replay;
+  var _channel;
+
+  this.setExtensionEnabled = function(extensionEnabled) {
+    _extensionEnabled = extensionEnabled;
+  }
+
+  this.setReplay = function (replay) {
+    _replay = parseInt(replay, 10);
+  }
+
+  this.setChannel = function(channel) {
+    _channel = channel;
+  }
+
+  this.incoming = function(message, callback) {
+    if (message.channel === '/meta/handshake') {
+      if (message.ext && message.ext[REPLAY_FROM_KEY] == true) {
+        _extensionEnabled = true;
+      }
+    } else if (message.channel === _channel && message.data && message.data.event && message.data.event.replayId) {
+      _replay = message.data.event.replayId;
+    }
+    callback(message);
+  }
+  
+  this.outgoing = function(message, callback) {
+    if (message.channel === '/meta/subscribe') {
+      if (_extensionEnabled) {
+        if (!message.ext) { message.ext = {}; }
+
+        var replayFromMap = {};
+        replayFromMap[_channel] = _replay;
+
+        // add "ext : { "replay" : { CHANNEL : REPLAY_VALUE }}" to subscribe message
+        message.ext[REPLAY_FROM_KEY] = replayFromMap;
+      }
+    }
+    callback(message);
+  };
+};
 
 /*--------------------------------------------*/
 /*

--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -41,42 +41,6 @@ Topic.prototype.subscribe = function(listener) {
 };
 
 /**
-<<<<<<< HEAD
-=======
- * Subscribe listener to topic with replay behavior and optional extensions
- *
- * @method Streaming~Topic#subscribeWithReplay
- * @param {Number} start the stream at replayId
- * @param {Array} additional Extensions
- * @param {Callback.<Streaming~StreamingMesasge>} listener - Streaming message listener
- * @returns {Subscription} - Faye subscription object
- */
-Topic.prototype.subscribeWithReplay = function(replayFrom, extensions, listener) {
-  var replayExt = new Streaming.cometdReplayExtension();
-  replayExt.setChannel(this.name);
-  replayExt.setReplay(replayFrom);
-  if (replayFrom != null) {
-    replayExt.setExtensionEnabled(true);
-  }
-  extensions = extensions instanceof Array ? extensions : [];
-  var allExtensions = [replayExt].concat(extensions);
-  return this._streaming.subscribeWithExtension(this.name, allExtensions, listener);
-};
-
-/**
- * Subscribe listener to topic with extensions
- *
- * @method Streaming~Topic#subscribeWithExtension
- * @param {Array} Extensions
- * @param {Callback.<Streaming~StreamingMesasge>} listener - Streaming message listener
- * @returns {Subscription} - Faye subscription object
- */
-Topic.prototype.subscribeWithExtension = function(extensions, listener) {
-  return this._streaming.subscribeWithExtension(this.name, extensions, listener);
-};
-
-/**
->>>>>>> d684512... Replay behavior for streaming topics
  * Unsubscribe listener from topic
  *
  * @method Streaming~Topic#unsubscribe
@@ -103,7 +67,7 @@ var Channel = function(streaming, name) {
 };
 
 /**
- * Subscribe to hannel
+ * Subscribe to channel
  *
  * @param {Callback.<Streaming~StreamingMessage>} listener - Streaming message listener
  * @returns {Subscription} - Faye subscription object
@@ -149,16 +113,28 @@ var Streaming = function(conn) {
 inherits(Streaming, events.EventEmitter);
 
 /** @private **/
-Streaming.prototype._createClient = function(replay) {
+Streaming.prototype._createClient = function(forChannelName, extensions) {
+  // forChannelName is advisory, for an API workaround. It does not restrict or select the channel.
+  var needsReplayFix = typeof forChannelName === 'string' && forChannelName.indexOf('/u/') === 0;
   var endpointUrl = [
     this._conn.instanceUrl,
     // special endpoint "/cometd/replay/xx.x" is only available in 36.0.
     // See https://releasenotes.docs.salesforce.com/en-us/summer16/release-notes/rn_api_streaming_classic_replay.htm
-    "cometd" + (replay && this._conn.version === "36.0" ? "/replay" : ""),
+    "cometd" + (needsReplayFix === true && this._conn.version === "36.0" ? "/replay" : ""),
     this._conn.version
   ].join('/');
   var fayeClient = new Faye.Client(endpointUrl, {});
   fayeClient.setHeader('Authorization', 'OAuth '+this._conn.accessToken);
+  if (extensions instanceof Array) {
+    extensions.forEach(function(extension) {
+      fayeClient.addExtension(extension);
+    });
+  }
+  if (fayeClient._dispatcher.getConnectionTypes().indexOf('callback-polling') === -1) {
+    // prevent streaming API server error
+    fayeClient._dispatcher.selectTransport('long-polling');
+    fayeClient._dispatcher._transport.batching = false;
+  }
   return fayeClient;
 };
 
@@ -168,12 +144,7 @@ Streaming.prototype._getFayeClient = function(channelName) {
   var clientType = isGeneric ? 'generic' : 'pushTopic';
   if (!this._fayeClients || !this._fayeClients[clientType]) {
     this._fayeClients = this._fayeClients || {};
-    this._fayeClients[clientType] = this._createClient(isGeneric);
-    if (this._fayeClients[clientType]._dispatcher.getConnectionTypes().indexOf('callback-polling') === -1) {
-      // prevent streaming API server error
-      this._fayeClients[clientType]._dispatcher.selectTransport('long-polling');
-      this._fayeClients[clientType]._dispatcher._transport.batching = false;
-    }
+    this._fayeClients[clientType] = this._createClient(channelName);
   }
   return this._fayeClients[clientType];
 };
@@ -228,8 +199,70 @@ Streaming.prototype.unsubscribe = function(name, listener) {
   return this;
 };
 
+
 /**
-<<<<<<< HEAD
+ * Create a Streaming client
+ *
+ * See Faye docs for implementation details: https://faye.jcoglan.com/browser/extensions.html
+ * 
+ * ```javascript
+ * // Establish a Salesforce connection. (Details elided)
+ * const conn = new jsforce.Connection({ … });
+ * 
+ * const fayeClient = conn.streaming.createClient();
+ * 
+ * const subscription = fayeClient.subscribe(channel, data => {
+ *   console.log('topic received data', data);
+ * });
+ * 
+ * subscription.cancel();
+ * ```
+ * 
+ * @returns {FayeClient} - Faye client object
+ */
+Streaming.prototype.createClient = function() {
+  return this._createClient(null);
+};
+
+/**
+ * Create a Streaming client with Faye extensions
+ *
+ * See Faye docs for implementation details: https://faye.jcoglan.com/browser/extensions.html
+ *
+ * For example, use the Replay extension & Auth Failure extension in a server-side Node.js app:
+ * 
+ * ```javascript
+ * // Establish a Salesforce connection. (Details elided)
+ * const conn = new jsforce.Connection({ … });
+ * 
+ * const channel = "/event/My_Event__e";
+ * const replayId = -2; // -2 is all retained events
+ * 
+ * const exitCallback = () => process.exit(1);
+ * const authFailureExt = new conn.streaming.AuthFailureExtension(exitCallback);
+ * 
+ * const replayExt = new conn.streaming.ReplayExtension(channel, replayId);
+ * 
+ * const fayeClient = conn.streaming.withExtensions([
+ *   authFailureExt,
+ *   replayExt
+ * ]);
+ * 
+ * const subscription = fayeClient.subscribe(channel, data => {
+ *   console.log('topic received data', data);
+ * });
+ * 
+ * subscription.cancel();
+ * ```
+ * 
+ * @param {Array} Extensions - Extensions to apply to the Faye client
+ * @returns {FayeClient} - Faye client object
+ */
+Streaming.prototype.withExtensions = function(extensions) {
+  return this._createClient(null, extensions);
+};
+
+/**
  * Auth failure detector extension
  *
  * Based on new feature released with Salesforce Spring '18:
@@ -248,7 +281,7 @@ Streaming.prototype.unsubscribe = function(name, listener) {
  *
  * @param {Function} failureCallback - Invoked when authentication becomes invalid
  */
-Streaming.authFailureExtension = function(failureCallback) {
+Streaming.prototype.AuthFailureExtension = function(failureCallback) {
   this.incoming = function(message, callback) {
     if (
       (message.channel === '/meta/connect' ||
@@ -264,19 +297,17 @@ Streaming.authFailureExtension = function(failureCallback) {
 };
 
 /**
-=======
->>>>>>> d684512... Replay behavior for streaming topics
  * Durable streaming replay extension
  *
  * Modified from original Salesforce demo source code:
  * https://github.com/developerforce/SalesforceDurableStreamingDemo/blob/3d4a56eac956f744ad6c22e6a8141b6feb57abb9/staticresources/cometdReplayExtension.resource
  */
-Streaming.cometdReplayExtension = function() {
+Streaming.prototype.ReplayExtension = function(channel, replayId) {
   var REPLAY_FROM_KEY = "replay";
   
-  var _extensionEnabled;
-  var _replay;
-  var _channel;
+  var _extensionEnabled = replayId != null ? true : false;
+  var _replay = replayId;
+  var _channel = channel;
 
   this.setExtensionEnabled = function(extensionEnabled) {
     _extensionEnabled = extensionEnabled;

--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -230,9 +230,9 @@ Streaming.prototype.unsubscribe = function(name, listener) {
  * const replayId = -2; // -2 is all retained events
  * 
  * const exitCallback = () => process.exit(1);
- * const authFailureExt = new conn.streaming.AuthFailureExtension(exitCallback);
+ * const authFailureExt = new jsforce.StreamingExtension.AuthFailure(exitCallback);
  * 
- * const replayExt = new conn.streaming.ReplayExtension(channel, replayId);
+ * const replayExt = new jsforce.StreamingExtension.Replay(channel, replayId);
  * 
  * const fayeClient = conn.streaming.createClient([
  *   authFailureExt,
@@ -252,92 +252,6 @@ Streaming.prototype.unsubscribe = function(name, listener) {
 Streaming.prototype.createClient = function(extensions) {
   return this._createClient(null, extensions);
 };
-
-/**
- * Auth failure detector extension
- *
- * Based on new feature released with Salesforce Spring '18:
- * https://releasenotes.docs.salesforce.com/en-us/spring18/release-notes/rn_messaging_cometd_auth_validation.htm?edition=&impact=
- *
- * Actual error message:
- * {
- *   "ext":{
- *     "sfdc":{"failureReason":"401::Authentication invalid"},
- *     "replay":true},
- *   "advice":{"reconnect":"none"},
- *   "channel":"/meta/handshake",
- *   "error":"403::Handshake denied",
- *   "successful":false
- * }
- *
- * @param {Function} failureCallback - Invoked when authentication becomes invalid
- */
-Streaming.prototype.AuthFailureExtension = function(failureCallback) {
-  this.incoming = function(message, callback) {
-    if (
-      (message.channel === '/meta/connect' ||
-        message.channel === '/meta/handshake')
-      && message.advice
-      && message.advice.reconnect == 'none'
-    ) {
-      failureCallback(message);
-    } else {
-      callback(message);
-    }
-  }
-};
-
-/**
- * Durable streaming replay extension
- *
- * Modified from original Salesforce demo source code:
- * https://github.com/developerforce/SalesforceDurableStreamingDemo/blob/3d4a56eac956f744ad6c22e6a8141b6feb57abb9/staticresources/cometdReplayExtension.resource
- */
-Streaming.prototype.ReplayExtension = function(channel, replayId) {
-  var REPLAY_FROM_KEY = "replay";
-  
-  var _extensionEnabled = replayId != null ? true : false;
-  var _replay = replayId;
-  var _channel = channel;
-
-  this.setExtensionEnabled = function(extensionEnabled) {
-    _extensionEnabled = extensionEnabled;
-  }
-
-  this.setReplay = function (replay) {
-    _replay = parseInt(replay, 10);
-  }
-
-  this.setChannel = function(channel) {
-    _channel = channel;
-  }
-
-  this.incoming = function(message, callback) {
-    if (message.channel === '/meta/handshake') {
-      if (message.ext && message.ext[REPLAY_FROM_KEY] == true) {
-        _extensionEnabled = true;
-      }
-    } else if (message.channel === _channel && message.data && message.data.event && message.data.event.replayId) {
-      _replay = message.data.event.replayId;
-    }
-    callback(message);
-  }
-  
-  this.outgoing = function(message, callback) {
-    if (message.channel === '/meta/subscribe') {
-      if (_extensionEnabled) {
-        if (!message.ext) { message.ext = {}; }
-
-        var replayFromMap = {};
-        replayFromMap[_channel] = _replay;
-
-        // add "ext : { "replay" : { CHANNEL : REPLAY_VALUE }}" to subscribe message
-        message.ext[REPLAY_FROM_KEY] = replayFromMap;
-      }
-    }
-    callback(message);
-  };
-}; 
 
 /*--------------------------------------------*/
 /*

--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -201,9 +201,11 @@ Streaming.prototype.unsubscribe = function(name, listener) {
 
 
 /**
- * Create a Streaming client
+ * Create a Streaming client, optionally with extensions
  *
  * See Faye docs for implementation details: https://faye.jcoglan.com/browser/extensions.html
+ *
+ * Example usage:
  * 
  * ```javascript
  * // Establish a Salesforce connection. (Details elided)
@@ -218,18 +220,7 @@ Streaming.prototype.unsubscribe = function(name, listener) {
  * subscription.cancel();
  * ```
  * 
- * @returns {FayeClient} - Faye client object
- */
-Streaming.prototype.createClient = function() {
-  return this._createClient(null);
-};
-
-/**
- * Create a Streaming client with Faye extensions
- *
- * See Faye docs for implementation details: https://faye.jcoglan.com/browser/extensions.html
- *
- * For example, use the Replay extension & Auth Failure extension in a server-side Node.js app:
+ * Example with extensions, using Replay & Auth Failure extensions in a server-side Node.js app:
  * 
  * ```javascript
  * // Establish a Salesforce connection. (Details elided)
@@ -243,7 +234,7 @@ Streaming.prototype.createClient = function() {
  * 
  * const replayExt = new conn.streaming.ReplayExtension(channel, replayId);
  * 
- * const fayeClient = conn.streaming.withExtensions([
+ * const fayeClient = conn.streaming.createClient([
  *   authFailureExt,
  *   replayExt
  * ]);
@@ -255,10 +246,10 @@ Streaming.prototype.createClient = function() {
  * subscription.cancel();
  * ```
  * 
- * @param {Array} Extensions - Extensions to apply to the Faye client
+ * @param {Array} Extensions - Optional, extensions to apply to the Faye client
  * @returns {FayeClient} - Faye client object
  */
-Streaming.prototype.withExtensions = function(extensions) {
+Streaming.prototype.createClient = function(extensions) {
   return this._createClient(null, extensions);
 };
 

--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -41,6 +41,42 @@ Topic.prototype.subscribe = function(listener) {
 };
 
 /**
+<<<<<<< HEAD
+=======
+ * Subscribe listener to topic with replay behavior and optional extensions
+ *
+ * @method Streaming~Topic#subscribeWithReplay
+ * @param {Number} start the stream at replayId
+ * @param {Array} additional Extensions
+ * @param {Callback.<Streaming~StreamingMesasge>} listener - Streaming message listener
+ * @returns {Subscription} - Faye subscription object
+ */
+Topic.prototype.subscribeWithReplay = function(replayFrom, extensions, listener) {
+  var replayExt = new Streaming.cometdReplayExtension();
+  replayExt.setChannel(this.name);
+  replayExt.setReplay(replayFrom);
+  if (replayFrom != null) {
+    replayExt.setExtensionEnabled(true);
+  }
+  extensions = extensions instanceof Array ? extensions : [];
+  var allExtensions = [replayExt].concat(extensions);
+  return this._streaming.subscribeWithExtension(this.name, allExtensions, listener);
+};
+
+/**
+ * Subscribe listener to topic with extensions
+ *
+ * @method Streaming~Topic#subscribeWithExtension
+ * @param {Array} Extensions
+ * @param {Callback.<Streaming~StreamingMesasge>} listener - Streaming message listener
+ * @returns {Subscription} - Faye subscription object
+ */
+Topic.prototype.subscribeWithExtension = function(extensions, listener) {
+  return this._streaming.subscribeWithExtension(this.name, extensions, listener);
+};
+
+/**
+>>>>>>> d684512... Replay behavior for streaming topics
  * Unsubscribe listener from topic
  *
  * @method Streaming~Topic#unsubscribe
@@ -193,6 +229,7 @@ Streaming.prototype.unsubscribe = function(name, listener) {
 };
 
 /**
+<<<<<<< HEAD
  * Auth failure detector extension
  *
  * Based on new feature released with Salesforce Spring '18:
@@ -227,6 +264,8 @@ Streaming.authFailureExtension = function(failureCallback) {
 };
 
 /**
+=======
+>>>>>>> d684512... Replay behavior for streaming topics
  * Durable streaming replay extension
  *
  * Modified from original Salesforce demo source code:
@@ -276,7 +315,7 @@ Streaming.cometdReplayExtension = function() {
     }
     callback(message);
   };
-};
+}; 
 
 /*--------------------------------------------*/
 /*

--- a/lib/core.js
+++ b/lib/core.js
@@ -14,3 +14,4 @@ jsforce.Date = jsforce.SfDate = require("./date");
 jsforce.RecordStream = require('./record-stream');
 jsforce.Promise = require('./promise');
 jsforce.require = require('./require');
+jsforce.StreamingExtension = require('./streaming-extension');

--- a/lib/streaming-extension.js
+++ b/lib/streaming-extension.js
@@ -1,0 +1,136 @@
+/**
+ * Faye Client extensions: https://faye.jcoglan.com/browser/extensions.html
+ *
+ * For use with Streaming.prototype.createClient()
+**/
+var StreamingExtension = {};
+
+/**
+ * Constructor for an auth failure detector extension
+ *
+ * Based on new feature released with Salesforce Spring '18:
+ * https://releasenotes.docs.salesforce.com/en-us/spring18/release-notes/rn_messaging_cometd_auth_validation.htm?edition=&impact=
+ *
+ * Example triggering error message:
+ *
+ * ```
+ * {
+ *   "ext":{
+ *     "sfdc":{"failureReason":"401::Authentication invalid"},
+ *     "replay":true},
+ *   "advice":{"reconnect":"none"},
+ *   "channel":"/meta/handshake",
+ *   "error":"403::Handshake denied",
+ *   "successful":false
+ * }
+ * ```
+ *
+ * Example usage:
+ *
+ * ```javascript
+ * const conn = new jsforce.Connection({ … });
+ * 
+ * const channel = "/event/My_Event__e";
+ * 
+ * // Exit the Node process when auth fails
+ * const exitCallback = () => process.exit(1);
+ * const authFailureExt = new jsforce.StreamingExtension.AuthFailure(exitCallback);
+ * 
+ * const fayeClient = conn.streaming.createClient([ authFailureExt ]);
+ * 
+ * const subscription = fayeClient.subscribe(channel, data => {
+ *   console.log('topic received data', data);
+ * });
+ * 
+ * subscription.cancel();
+ * ```
+ *
+ * @param {Function} failureCallback - Invoked when authentication becomes invalid
+ */
+StreamingExtension.AuthFailure = function(failureCallback) {
+  this.incoming = function(message, callback) {
+    if (
+      (message.channel === '/meta/connect' ||
+        message.channel === '/meta/handshake')
+      && message.advice
+      && message.advice.reconnect == 'none'
+    ) {
+      failureCallback(message);
+    } else {
+      callback(message);
+    }
+  }
+};
+
+/**
+ * Constructor for a durable streaming replay extension
+ *
+ * Modified from original Salesforce demo source code:
+ * https://github.com/developerforce/SalesforceDurableStreamingDemo/blob/3d4a56eac956f744ad6c22e6a8141b6feb57abb9/staticresources/cometdReplayExtension.resource
+ * 
+ * Example usage:
+ *
+ * ```javascript
+ * const conn = new jsforce.Connection({ … });
+ * 
+ * const channel = "/event/My_Event__e";
+ * const replayId = -2; // -2 is all retained events
+ * 
+ * const replayExt = new jsforce.StreamingExtension.Replay(channel, replayId);
+ * 
+ * const fayeClient = conn.streaming.createClient([ replayExt ]);
+ * 
+ * const subscription = fayeClient.subscribe(channel, data => {
+ *   console.log('topic received data', data);
+ * });
+ * 
+ * subscription.cancel();
+ * ```
+ */
+StreamingExtension.Replay = function(channel, replayId) {
+  var REPLAY_FROM_KEY = "replay";
+  
+  var _extensionEnabled = replayId != null ? true : false;
+  var _replay = replayId;
+  var _channel = channel;
+
+  this.setExtensionEnabled = function(extensionEnabled) {
+    _extensionEnabled = extensionEnabled;
+  }
+
+  this.setReplay = function (replay) {
+    _replay = parseInt(replay, 10);
+  }
+
+  this.setChannel = function(channel) {
+    _channel = channel;
+  }
+
+  this.incoming = function(message, callback) {
+    if (message.channel === '/meta/handshake') {
+      if (message.ext && message.ext[REPLAY_FROM_KEY] == true) {
+        _extensionEnabled = true;
+      }
+    } else if (message.channel === _channel && message.data && message.data.event && message.data.event.replayId) {
+      _replay = message.data.event.replayId;
+    }
+    callback(message);
+  }
+  
+  this.outgoing = function(message, callback) {
+    if (message.channel === '/meta/subscribe') {
+      if (_extensionEnabled) {
+        if (!message.ext) { message.ext = {}; }
+
+        var replayFromMap = {};
+        replayFromMap[_channel] = _replay;
+
+        // add "ext : { "replay" : { CHANNEL : REPLAY_VALUE }}" to subscribe message
+        message.ext[REPLAY_FROM_KEY] = replayFromMap;
+      }
+    }
+    callback(message);
+  };
+};
+
+module.exports = StreamingExtension;


### PR DESCRIPTION
First of all, thank you @stomita for creating & sharing this amazing library 🙏 🙇 😊 

I've been working on a few projects internally at Salesforce that use the jsforce Streaming API to subscribe to **[Platform Events](https://developer.salesforce.com/docs/atlas.en-us.212.0.platform_events.meta/platform_events/platform_events_intro.htm)** (GA/released) and **[Change Data Capture](https://releasenotes.docs.salesforce.com/en-us/spring18/release-notes/rn_data_change_events.htm?edition=&impact=)** (pilot) streams.

🔺 **Breaking changes to this PR as of 2018-07-17.** If you're tracking this branch to use these features, please update your client code to use the newest API:
  * `conn.streaming.createClient()` is now the only way to construct a new Faye client with extensions; `withExtensions()` has been removed
  * the provided `AuthFailure` & `Replay` extensions have been moved into a new ` jsforce.StreamingExtension` module and renamed

### New Features

This pull request contains three features which bring jsforce Streaming up-to-date with the current capabilities of the Salesforce Streaming API.

1. **Support for [Faye extensions](https://faye.jcoglan.com/browser/extensions.html)** Provides direct access to new Faye clients so they can be extended and managed by the developer. Example usage:
    ```javascript
    // Establish an authenticated Salesforce connection. (Details elided)
    const conn = new jsforce.Connection({ … });

    const channel = "/event/My_Event__e";

    const loggerExtension = {
      incoming: function(message, callback) {
        console.log('extension received message', message);
        callback(message);
      }
    };

    // Create a client and dynamically add extensions:
    const fayeClient = conn.streaming.createClient();
    fayeClient.addExtension(loggerExtension);
    //
    // …or create the extended client directly:
    const fayeClient = conn.streaming.createClient([ loggerExtension ]);

    const subscription = fayeClient.subscribe(channel, data => {
      console.log('topic received data', data);
    });

    subscription.cancel();
    ```
1. **Replay extension** to support [durable streams](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm). Example usage:
    ```javascript
    // Establish an authenticated Salesforce connection. (Details elided)
    const conn = new jsforce.Connection({ … });

    const channel = "/event/My_Event__e";
    const replayId = -2; // -2 is all retained events

    const replayExt = new jsforce.StreamingExtension.Replay(channel, replayId);

    const fayeClient = conn.streaming.createClient([ replayExt ]);

    const subscription = fayeClient.subscribe(channel, data => {
      console.log('topic received data', data);
    });

    subscription.cancel();
    ```

    🤨 Please note, this is not a complete durability solution. Each individual app will still need to implement persistent storage to capture and recall the last seen `replayId`. For example, [here's an app that uses Redis to track the last processed ID](https://github.com/mars/event-driven-functions/blob/master/lib/salesforce-observer.js) using this pull request's fork/branch.
1. **Auth Failure detection extension** defines behavior for when a [Streaming connection stops receiving messages but does not disconnect](https://releasenotes.docs.salesforce.com/en-us/spring18/release-notes/rn_messaging_cometd_auth_validation.htm?edition=&impact=). Not activated by default, because failure handling is app specific. Example usage:
    ```javascript
    // Establish a Salesforce connection. (Details elided)
    const conn = new jsforce.Connection({ … });

    const channel = "/event/My_Event__e";

    // Exit the Node process when auth fails
    const exitCallback = () => process.exit(1);
    const authFailureExt = new jsforce.StreamingExtension.AuthFailure(exitCallback);

    const fayeClient = conn.streaming.createClient([ authFailureExt ]);

    const subscription = fayeClient.subscribe(channel, data => {
      console.log('topic received data', data);
    });

    subscription.cancel();
    ```

### Existing Pull Requests

A couple of pull requests are open that attempt to solve similar or part of the same problem. Here's my perspective on them:

#664: Implements a new module `PlatformEvent` which is unnecessary. Platform Events are delivered as topics on the main Streaming API, e.g. `/event/My_Custom_Event__e`. Why is a new module required? Keeping all Streaming API's under the same `Streaming` module will reduce cognitive overhead and code sprawl/duplication.

#676: Implements only the Faye/Bayeux/CometD client extension mechanism. This was the original source of the extension-based features in this pull request, but is no longer the foundation because of concerns with mutability of shared Faye clients.

### Sample usage

Check out this [reference implementation of a durable Salesforce streaming client](https://github.com/mars/event-driven-functions/blob/master/lib/salesforce-observer.js) which uses this pull request's fork/branch via [npm git dependency](https://github.com/mars/event-driven-functions/blob/master/package.json#L26).

### Merging

It's my goal to see this through to merge, as these features are becoming critical for the Salesforce Streaming API story. As this progresses, I will also PR to update the jsforce docs. Please let me know of any changes or additions you would like to see. Again, thank you for all your time and effort!