### PR TITLE
Use user's responeType while sending xhr

### DIFF
--- a/lib/browser/request.js
+++ b/lib/browser/request.js
@@ -12,6 +12,12 @@ module.exports = function(params, callback) {
     }
   }
   xhr.setRequestHeader("Accept", "*/*");
+
+  // Respect user's responseType to xhr
+  if(params.responseType != null && params.responseType) {
+    xhr.responseType = params.responseType;
+  }
+
   var response;
   var str = new Duplex();
   str._read = function(size) {

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -45,6 +45,8 @@ HttpApi.prototype.request = function(request, callback) {
   // remember previous instance url in case it changes after a refresh
   var lastInstanceUrl = conn.instanceUrl;
 
+  request.responseType = this._responseType;
+
   var deferred = Promise.defer();
 
   var onResume = function(err) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -184,6 +184,9 @@ ProxyTransport.prototype.httpRequest = function(params, callback) {
       proxyParams.headers[name] = params.headers[name];
     }
   }
+  if(params.responseType != null && params.responseType.length > 0) {
+    proxyParams.responseType = params.responseType;
+  }
   return ProxyTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
 };
 
@@ -228,6 +231,9 @@ HttpProxyTransport.prototype.httpRequest = function(params, callback) {
     for (var name in params.headers) {
       proxyParams.headers[name] = params.headers[name];
     }
+  }
+  if(params.responseType != null && params.responseType.length > 0) {
+    proxyParams.responseType = params.responseType;
   }
   return HttpProxyTransport.super_.prototype.httpRequest.call(this, proxyParams, callback);
 };


### PR DESCRIPTION
We have already documented `responseType` parameter in `options` while sending a request, however it is not actually set into xhr.
This is useful while defining responseType to something like a blob.

Eg, when we are downloading an attachment on browser, we can skip conversion process and straightaway get url of blob.  

    var urlCreator = window.URL || window.webkitURL;
    record.Body = ''; // Attachment url received 
    var options = { responseType: 'blob' };
    connection.request(record.Body, options, function (err, blob) {
        if (err) { return console.error(err); }

        var location = urlCreator.createObjectURL(blob); // do something like set img src
        console.log("location: " + location);
    }

**References**
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType

Signed-off-by: Varun Garg <varun.10@live.com>