### PR TITLE
replace deprecated `open` with `opn`

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -8,7 +8,7 @@
 
 var http = require('http'),
     url = require('url'),
-    openUrl = require('open'),
+    openUrl = require('opn'),
     commander = require('commander'),
     coprompt = require('co-prompt'),
     Repl = require('./repl'),

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "inherits": "^2.0.1",
     "lodash": "^4.11.1",
     "multistream": "^2.0.5",
-    "open": "0.0.5",
+    "opn": "^5.3.0",
     "promise": "^7.1.1",
     "readable-stream": "^2.1.0",
     "request": "^2.72.0",


### PR DESCRIPTION
Fixes: https://github.com/jsforce/jsforce/issues/751, https://nodesecurity.io/advisories/663

`open` appears to have a command injection vulnerability. This is causing any project with `jsforce` as a dependency to fail the node security platform check https://github.com/nodesecurity/nsp. 

The fix is to use `opn`.  Luckily the API is the same, so very little to change.