### PR TITLE
Allow send XML or raw data with Apex

### DIFF
--- a/lib/api/apex.js
+++ b/lib/api/apex.js
@@ -43,7 +43,7 @@ Apex.prototype._createRequestParams = function(method, path, body, options) {
   if (body) {
     params.body = body;
     if (typeof body === 'object')
-     params.body = JSON.stringify(body);
+      params.body = JSON.stringify(body);
     }
   }
   return params;

--- a/lib/api/apex.js
+++ b/lib/api/apex.js
@@ -1,51 +1,177 @@
+/**
+ * @file Manages Salesforce Apex REST endpoint calls
+ * @author Shinichi Tomita <shinichi.tomita@gmail.com>
+ */
 
-import * as _ from 'lodash';
+'use strict';
 
-import {
-    State,
-    Subscription,
-    SalesforceGetAccountsStatusesResponse,
-} from '../../models';
-import { config } from '../../config';
-import { newErrors as errors } from '../../errors';
-import * as remote from './remote';
+var jsforce = require('../core');
 
-let jsforce;
-let connection;
+/**
+ * API class for Apex REST endpoint call
+ *
+ * @class
+ * @param {Connection} conn Connection
+ */
+var Apex = function(conn) {
+  this._conn = conn;
+};
 
-if (config.params.mockSalesforceApi) {
-    jsforce = require('./remote/mock').jsforce;
-} else {
-    jsforce = require('jsforce');
-}
+/**
+ * @private
+ */
+Apex.prototype._baseUrl = function() {
+  return this._conn.instanceUrl + "/services/apexrest";
+};
 
-export async function initPromise(state: State) {
-    try {
-        connection = await remote.getConnection(config.salesforceApi, state);
-        state.logger.debug('login successful');
-    } catch (err) {
-        const msg = 'Could not connect to Salesforce API.';
-        state.logger.error({ err }, msg);
-        throw errors.badGateway('Salesforce Remote Connection Error');
+/**
+ * @private
+ */
+Apex.prototype._createRequestParams = function(method, path, body, options) {
+  var params = {
+    method: method,
+    url: this._baseUrl() + path
+  },
+  _headers = {};
+  if(options && 'object' === typeof options['headers']){
+    _headers = options['headers'];
+  }
+  if (!/^(GET|DELETE)$/i.test(method) && !_headers["Content-Type"]) {
+    _headers["Content-Type"] = "application/json";
+  }
+  params.headers = _headers;
+  if (body) {
+    params.body = body;
+    if ('object' === typeof options['body']) {
+      params.body = JSON.stringify(body);
     }
-}
+  }
+  return params;
+};
 
-export async function notifyKeyDate(subscription: Subscription, state: State): Promise<string> {
-    try {
-        const response = await remote.notifyKeyDate(subscription);
-        return response;
-    } catch (error) {
-        state.logger.error({ error, response: _.pick(_.get(error, 'response'), ['status']) }, 'Salesforce Remote Notify Error');
-        throw errors.badGateway('Salesforce Remote Notify Error');
-    }
-}
+/**
+ * Call Apex REST service in GET request
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} options - Holds headers and other meta data for the request.
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Apex.prototype.get = function(path, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  return this._conn.request(this._createRequestParams('GET', path, undefined, options)).thenCall(callback);
+};
 
-export async function getAccountsStatuses(crmIds: string[], state: State): Promise<SalesforceGetAccountsStatusesResponse> {
-    try {
-        const response = await remote.getAccountsStatuses(crmIds);
-        return <SalesforceGetAccountsStatusesResponse>response;
-    } catch (error) {
-        state.logger.error({ error, response: _.pick(_.get(error, 'response'), ['status']) }, 'Salesforce Remote Get Data Query Error');
-        throw errors.badGateway('Salesforce Remote Get Data Query Error');
-    }
-}
+/**
+ * Call Apex REST service in POST request
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} [body] - Request body
+ * @param {Object} options - Holds headers and other meta data for the request.
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Apex.prototype.post = function(path, body, options, callback) {
+  if (typeof body === 'function') {
+    callback = body;
+    body = undefined;
+    options = undefined;
+  }
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var params = this._createRequestParams('POST', path, body, options);
+  return this._conn.request(params).thenCall(callback);
+};
+
+/**
+ * Call Apex REST service in PUT request
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} [body] - Request body
+ * @param {Object} [options] - Holds headers and other meta data for the request.
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Apex.prototype.put = function(path, body, options, callback) {
+  if (typeof body === 'function') {
+    callback = body;
+    body = undefined;
+    options = undefined;
+  }
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var params = this._createRequestParams('PUT', path, body, options);
+  return this._conn.request(params).thenCall(callback);
+};
+
+/**
+ * Call Apex REST service in PATCH request
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} [body] - Request body
+ * @param {Object} [options] - Holds headers and other meta data for the request.
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Apex.prototype.patch = function(path, body, options, callback) {
+  if (typeof body === 'function') {
+    callback = body;
+    body = undefined;
+    options = undefined;
+  }
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  var params = this._createRequestParams('PATCH', path, body, options);
+  return this._conn.request(params).thenCall(callback);
+};
+
+/**
+ * Synonym of Apex#delete()
+ *
+ * @method Apex#del
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} [body] - Request body
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+/**
+ * Call Apex REST service in DELETE request
+ *
+ * @method Apex#delete
+ *
+ * @param {String} path - URL path to Apex REST service
+ * @param {Object} [body] - Request body
+ * @param {Object} [options] - Holds headers and other meta data for the request.
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Apex.prototype.del =
+  Apex.prototype["delete"] = function(path, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+  return this._conn.request(this._createRequestParams('DELETE', path, undefined, options)).thenCall(callback);
+};
+
+
+/*--------------------------------------------*/
+/*
+ * Register hook in connection instantiation for dynamically adding this API module features
+ */
+jsforce.on('connection:new', function(conn) {
+  conn.apex = new Apex(conn);
+});
+
+
+module.exports = Apex;

--- a/lib/api/apex.js
+++ b/lib/api/apex.js
@@ -1,174 +1,51 @@
-/**
- * @file Manages Salesforce Apex REST endpoint calls
- * @author Shinichi Tomita <shinichi.tomita@gmail.com>
- */
 
-'use strict';
+import * as _ from 'lodash';
 
-var jsforce = require('../core');
+import {
+    State,
+    Subscription,
+    SalesforceGetAccountsStatusesResponse,
+} from '../../models';
+import { config } from '../../config';
+import { newErrors as errors } from '../../errors';
+import * as remote from './remote';
 
-/**
- * API class for Apex REST endpoint call
- *
- * @class
- * @param {Connection} conn Connection
- */
-var Apex = function(conn) {
-  this._conn = conn;
-};
+let jsforce;
+let connection;
 
-/**
- * @private
- */
-Apex.prototype._baseUrl = function() {
-  return this._conn.instanceUrl + "/services/apexrest";
-};
+if (config.params.mockSalesforceApi) {
+    jsforce = require('./remote/mock').jsforce;
+} else {
+    jsforce = require('jsforce');
+}
 
-/**
- * @private
- */
-Apex.prototype._createRequestParams = function(method, path, body, options) {
-  var params = {
-    method: method,
-    url: this._baseUrl() + path
-  },
-  _headers = {};
-  if(options && 'object' === typeof options['headers']){
-    _headers = options['headers'];
-  }
-  if (!/^(GET|DELETE)$/i.test(method)) {
-    _headers["Content-Type"] = "application/json";
-  }
-  params.headers = _headers;
-  if (body) {
-    params.body = JSON.stringify(body);
-  }
-  return params;
-};
+export async function initPromise(state: State) {
+    try {
+        connection = await remote.getConnection(config.salesforceApi, state);
+        state.logger.debug('login successful');
+    } catch (err) {
+        const msg = 'Could not connect to Salesforce API.';
+        state.logger.error({ err }, msg);
+        throw errors.badGateway('Salesforce Remote Connection Error');
+    }
+}
 
-/**
- * Call Apex REST service in GET request
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} options - Holds headers and other meta data for the request.
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-Apex.prototype.get = function(path, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  return this._conn.request(this._createRequestParams('GET', path, undefined, options)).thenCall(callback);
-};
+export async function notifyKeyDate(subscription: Subscription, state: State): Promise<string> {
+    try {
+        const response = await remote.notifyKeyDate(subscription);
+        return response;
+    } catch (error) {
+        state.logger.error({ error, response: _.pick(_.get(error, 'response'), ['status']) }, 'Salesforce Remote Notify Error');
+        throw errors.badGateway('Salesforce Remote Notify Error');
+    }
+}
 
-/**
- * Call Apex REST service in POST request
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} [body] - Request body
- * @param {Object} options - Holds headers and other meta data for the request.
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-Apex.prototype.post = function(path, body, options, callback) {
-  if (typeof body === 'function') {
-    callback = body;
-    body = undefined;
-    options = undefined;
-  }
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  var params = this._createRequestParams('POST', path, body, options);
-  return this._conn.request(params).thenCall(callback);
-};
-
-/**
- * Call Apex REST service in PUT request
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} [body] - Request body
- * @param {Object} [options] - Holds headers and other meta data for the request.
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-Apex.prototype.put = function(path, body, options, callback) {
-  if (typeof body === 'function') {
-    callback = body;
-    body = undefined;
-    options = undefined;
-  }
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  var params = this._createRequestParams('PUT', path, body, options);
-  return this._conn.request(params).thenCall(callback);
-};
-
-/**
- * Call Apex REST service in PATCH request
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} [body] - Request body
- * @param {Object} [options] - Holds headers and other meta data for the request.
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-Apex.prototype.patch = function(path, body, options, callback) {
-  if (typeof body === 'function') {
-    callback = body;
-    body = undefined;
-    options = undefined;
-  }
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  var params = this._createRequestParams('PATCH', path, body, options);
-  return this._conn.request(params).thenCall(callback);
-};
-
-/**
- * Synonym of Apex#delete()
- *
- * @method Apex#del
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} [body] - Request body
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-/**
- * Call Apex REST service in DELETE request
- *
- * @method Apex#delete
- *
- * @param {String} path - URL path to Apex REST service
- * @param {Object} [body] - Request body
- * @param {Object} [options] - Holds headers and other meta data for the request.
- * @param {Callback.<Object>} [callback] - Callback function
- * @returns {Promise.<Object>}
- */
-Apex.prototype.del =
-  Apex.prototype["delete"] = function(path, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  return this._conn.request(this._createRequestParams('DELETE', path, undefined, options)).thenCall(callback);
-};
-
-
-/*--------------------------------------------*/
-/*
- * Register hook in connection instantiation for dynamically adding this API module features
- */
-jsforce.on('connection:new', function(conn) {
-  conn.apex = new Apex(conn);
-});
-
-
-module.exports = Apex;
+export async function getAccountsStatuses(crmIds: string[], state: State): Promise<SalesforceGetAccountsStatusesResponse> {
+    try {
+        const response = await remote.getAccountsStatuses(crmIds);
+        return <SalesforceGetAccountsStatusesResponse>response;
+    } catch (error) {
+        state.logger.error({ error, response: _.pick(_.get(error, 'response'), ['status']) }, 'Salesforce Remote Get Data Query Error');
+        throw errors.badGateway('Salesforce Remote Get Data Query Error');
+    }
+}

--- a/lib/api/apex.js
+++ b/lib/api/apex.js
@@ -42,8 +42,8 @@ Apex.prototype._createRequestParams = function(method, path, body, options) {
   params.headers = _headers;
   if (body) {
     params.body = body;
-    if ('object' === typeof options['body']) {
-      params.body = JSON.stringify(body);
+    if (typeof body === 'object')
+     params.body = JSON.stringify(body);
     }
   }
   return params;


### PR DESCRIPTION
I need to make this request:

POST /services/apexrest/KeyDate

``` 
<?xml version="1.0" encoding="UTF-8"?>
<callout>
    <parameter name="AccountID">{Zuora account Id}</parameter>
</callout>
```

If JSON.stringify is forced and content-type as well, I cannot do this. However with the update above, this call will go through:

```
    const body = `<?xml version="1.0" encoding="UTF-8"?>
    <callout>
        <parameter name="AccountID">${subscription.accountId}</parameter>
     </callout>`;

    return connection.apex.post('/KeyDate/', body, { headers: { 'Content-Type': 'application/xml' } });
```