### PR TITLE
Replace the open dependency with opn

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -8,7 +8,7 @@
 
 var http = require('http'),
     url = require('url'),
-    openUrl = require('open'),
+    openUrl = require('opn'),
     commander = require('commander'),
     coprompt = require('co-prompt'),
     Repl = require('./repl'),

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "inherits": "^2.0.1",
     "lodash": "^4.11.1",
     "multistream": "^2.0.5",
-    "open": "0.0.5",
+    "opn": "^5.3.0",
     "promise": "^7.1.1",
     "readable-stream": "^2.1.0",
     "request": "^2.72.0",


### PR DESCRIPTION
There is currently an advisory for [open](https://github.com/pwnall/node-open): https://nodesecurity.io/advisories/663.
This is not a huge issue, since it doesn't appear that node-open ever gets passed unsanitized user input. However users of the jsforce library do see a critical severity vulnerability because of node-open when running `npm audit`. This pull request removes the node-open dependency and replaces it with [opn](https://github.com/sindresorhus/opn), which is more secure and actually maintained.