### PR TITLE
Get instanceUrl from signedRequest

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -197,6 +197,7 @@ Connection.prototype.initialize = function(options) {
   this.signedRequest = options.signedRequest && parseSignedRequest(options.signedRequest);
   if (this.signedRequest) {
     this.accessToken = this.signedRequest.client.oauthToken;
+    this.instanceUrl = this.signedRequest.client.instanceUrl;
     if (Transport.CanvasTransport.supported) {
       this._transport = new Transport.CanvasTransport(this.signedRequest);
     }


### PR DESCRIPTION
When authorizing via a signed request, the instanceUrl is may not be set in the options passed to the initializer. At any rate, the instanceUrl should be set to the value found on the signed request, as this is the authenticating service.