### PR TITLE
Add additional CRUD functions using "composite resources", to better handle writes to a "medium" number of records

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -689,6 +689,8 @@ Connection.prototype.createMany = function(type, records, options, callback) {
   records = isArray ? records : [ records ];
   if (records.length > self.maxRequest) {
     return Promise.reject(new Error("Exceeded max limit of concurrent call")).thenCall(callback);
+  } else if (!records.length) {
+    return Promise.resolve([]).thenCall(callback);
   }
   records = _.map(records, function(record) {
     var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
@@ -774,6 +776,69 @@ Connection.prototype.update = function(type, records, options, callback) {
       });
     })
   ).then(function(results) {
+    return !isArray && _.isArray(results) ? results[0] : results;
+  }).thenCall(callback);
+};
+
+/**
+ * Update multiple records with fewer round trips
+ *
+ * @param {String} type - SObject Type
+ * @param {Record|Array.<Record>} records - A record or array of records to update
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+Connection.prototype.updateMany = function(type, records, options, callback) {
+  if (!_.isString(type)) {
+    // reverse order
+    callback = options;
+    options = records;
+    records = type;
+    type = null;
+  }
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+  var self = this;
+  var isArray = _.isArray(records);
+  records = isArray ? records : [ records ];
+  if (records.length > self.maxRequest) {
+    return Promise.reject(new Error("Exceeded max limit of concurrent call")).thenCall(callback);
+  } else if (!records.length) {
+    return Promise.resolve([]).thenCall(callback);
+  }
+  records = _.map(records, function(record) {
+    var id = record.Id;
+    if (!id) {
+      throw new Error('Record id is not found in record.');
+    }
+    var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
+    if (!sobjectType) {
+      throw new Error('No SObject Type defined in record');
+    }
+    record = _.clone(record);
+    delete record.Id;
+    record.id = id;
+    delete record.type;
+    record.attributes = { type : sobjectType };
+    return record;
+  });
+
+  var url = [ self._baseUrl(), "composite", "sobjects" ].join('/');
+  return self.request({
+    method : 'PATCH',
+    url : url,
+    body : JSON.stringify({
+      allOrNone : false,
+      records : records
+    }),
+    headers : _.defaults(options.headers || {}, {
+      "Content-Type" : "application/json"
+    })
+  }).then(function(results) {
     return !isArray && _.isArray(results) ? results[0] : results;
   }).thenCall(callback);
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,7 +23,7 @@ var events  = require('events'),
 var defaults = {
   loginUrl: "https://login.salesforce.com",
   instanceUrl: "",
-  version: "39.0"
+  version: "42.0"
 };
 
 /**
@@ -647,6 +647,73 @@ Connection.prototype.create = function(type, records, options, callback) {
       });
     })
   ).then(function(results) {
+    return !isArray && _.isArray(results) ? results[0] : results;
+  }).thenCall(callback);
+};
+
+/**
+ * Synonym of Connection#createMany()
+ *
+ * @method Connection#insertMany
+ * @param {String} type - SObject Type
+ * @param {Object|Array.<Object>} records - A record or array of records to create
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Create multiple records with fewer round trips
+ *
+ * @method Connection#createMany
+ * @param {String} type - SObject Type
+ * @param {Record|Array.<Record>} records - A record or array of records to create
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+Connection.prototype.insertMany =
+Connection.prototype.createMany = function(type, records, options, callback) {
+  if (!_.isString(type)) {
+    // reverse order
+    callback = options;
+    options = records;
+    records = type;
+    type = null;
+  }
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+  var self = this;
+  var isArray = _.isArray(records);
+  records = isArray ? records : [ records ];
+  if (records.length > self.maxRequest) {
+    return Promise.reject(new Error("Exceeded max limit of concurrent call")).thenCall(callback);
+  }
+  records = _.map(records, function(record) {
+    var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
+    if (!sobjectType) {
+      throw new Error('No SObject Type defined in record');
+    }
+    record = _.clone(record);
+    delete record.Id;
+    delete record.type;
+    record.attributes = { type : sobjectType };
+    return record;
+  });
+
+  var url = [ self._baseUrl(), "composite", "sobjects" ].join('/');
+  return self.request({
+    method : 'POST',
+    url : url,
+    body : JSON.stringify({
+      allOrNone : false,
+      records : records
+    }),
+    headers : _.defaults(options.headers || {}, {
+      "Content-Type" : "application/json"
+    })
+  }).then(function(results) {
     return !isArray && _.isArray(results) ? results[0] : results;
   }).thenCall(callback);
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -961,6 +961,63 @@ Connection.prototype.destroy = function(type, ids, options, callback) {
 };
 
 /**
+ * Synonym of Connection#destroyMany()
+ *
+ * @method Connection#deleteMany
+ * @param {String} type - SObject Type
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Synonym of Connection#destroyMany()
+ *
+ * @method Connection#delMany
+ * @param {String} type - SObject Type
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Delete multiple records with fewer round trips
+ *
+ * @method Connection#destroyMany
+ * @param {String} type - SObject Type
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+Connection.prototype["deleteMany"] =
+Connection.prototype.delMany =
+Connection.prototype.destroyMany = function(type, ids, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+  var self = this;
+  var isArray = _.isArray(ids);
+  ids = isArray ? ids : [ ids ];
+  if (ids.length > self.maxRequest) {
+    return Promise.reject(new Error("Exceeded max limit of concurrent call")).thenCall(callback);
+  } else if (!ids.length) {
+    return Promise.resolve([]).thenCall(callback);
+  }
+
+  var url = [ self._baseUrl(), "composite", "sobjects?ids=" ].join('/') + ids.join(',');
+  return self.request({
+    method : 'DELETE',
+    url : url,
+    headers: options.headers || null
+  }).then(function(results) {
+    return !isArray && _.isArray(results) ? results[0] : results;
+  }).thenCall(callback);
+};
+
+/**
  * Execute search by SOSL
  *
  * @param {String} sosl - SOSL string

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -63,6 +63,32 @@ SObject.prototype.create = function(records, options, callback) {
 };
 
 /**
+ * Synonym of SObject#createMany()
+ *
+ * @method SObject#insertMany
+ * @param {Record|Array.<Record>} records - A record or array of records to create
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Create multiple records with fewer round trips
+ *
+ * @method SObject#createMany
+ * @param {Record|Array.<Record>} records - A record or array of records to create
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+SObject.prototype.insertMany =
+SObject.prototype.createMany = function(records, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  return this._conn.createMany(this.type, records, options, callback);
+};
+
+/**
  * Retrieve specified records
  *
  * @param {String|Array.<String>} ids - A record ID or array of record IDs

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -189,6 +189,41 @@ SObject.prototype.destroy = function(ids, options, callback) {
 };
 
 /**
+ * Synonym of SObject#destroyMany()
+ *
+ * @method SObject#deleteMany
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Synonym of SObject#destroyMany()
+ *
+ * @method SObject#delMany
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+/**
+ * Delete multiple records with fewer round trips
+ *
+ * @method SObject#destroyMany
+ * @param {String|Array.<String>} ids - A ID or array of IDs to delete
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+SObject.prototype["deleteMany"] =
+SObject.prototype.delMany =
+SObject.prototype.destroyMany = function(ids, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  return this._conn.destroyMany(this.type, ids, options, callback);
+};
+
+/**
  * Describe SObject metadata
  *
  * @param {Callback.<DescribeSObjectResult>} [callback] - Callback function

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -121,6 +121,22 @@ SObject.prototype.update = function(records, options, callback) {
 };
 
 /**
+ * Update multiple records with fewer round trips
+ *
+ * @param {Record|Array.<Record>} records - A record or array of records to update
+ * @param {Object} [options] - Options for rest api.
+ * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
+ * @returns {Promise.<RecordResult|Array.<RecordResult>>}
+ */
+SObject.prototype.updateMany = function(records, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  return this._conn.updateMany(this.type, records, options, callback);
+};
+
+/**
  * Upsert records
  *
  * @param {Record|Array.<Record>} records - Record or array of records to upsert

--- a/test/connection-crud-many.test.js
+++ b/test/connection-crud-many.test.js
@@ -1,0 +1,163 @@
+/*global describe, it, before, after */
+var TestEnv = require('./helper/testenv'),
+    assert = TestEnv.assert;
+
+var async  = require('async'),
+    _      = require('lodash/core'),
+    sf     = require('../lib/jsforce'),
+    config = require('./config/salesforce');
+
+var testEnv = new TestEnv(config);
+
+/**
+ *
+ */
+describe("connection-crud-many", function() {
+
+  this.timeout(40000); // set timeout to 40 sec.
+
+  var conn = testEnv.createConnection();
+
+  /**
+   *
+   */
+  before(function(done) {
+    this.timeout(600000); // set timeout to 10 min.
+    testEnv.establishConnection(conn, done);
+  });
+
+  var accountId, account;
+  /**
+   *
+   */
+  describe("create account", function() {
+    it("should return created obj", function(done) {
+      conn.sobject('Account').createMany({ Name : 'Hello' }, function(err, ret) {
+        if (err) { throw err; }
+        assert.ok(ret.success);
+        assert.ok(_.isString(ret.id));
+        accountId = ret.id;
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("retrieve account", function() {
+    it("should return a record", function(done) {
+      conn.sobject('Account').retrieve(accountId, function(err, record) {
+        if (err) { throw err; }
+        assert.ok(_.isString(record.Id));
+        assert.ok(_.isObject(record.attributes));
+        assert.ok(record.Name === 'Hello');
+        account = record;
+      }.check(done));
+    });
+  });
+
+
+  var accountIds, accounts;
+  /**
+   *
+   */
+  describe("create multiple accounts", function() {
+    it("should return created records", function(done) {
+      conn.sobject('Account').createMany([
+        { Name : 'Account #1' },
+        { Name : 'Account #2' }
+      ], function(err, rets) {
+        if (err) { throw err; }
+        assert.ok(_.isArray(rets));
+        rets.forEach(function(ret) {
+          assert.ok(ret.success);
+          assert.ok(_.isString(ret.id));
+        });
+        accountIds = rets.map(function(ret){ return ret.id; });
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("retrieve multiple accounts", function() {
+    it("should return specified records", function(done) {
+      conn.sobject('Account').retrieve(accountIds, function(err, records) {
+        if (err) { throw err; }
+        assert.ok(_.isArray(records));
+        records.forEach(function(record, i) {
+          assert.ok(_.isString(record.Id));
+          assert.ok(_.isObject(record.attributes));
+          assert.ok(record.Name === 'Account #' + (i+1));
+        });
+        accounts = records;
+      }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("update multiple accounts", function() {
+    it("should update records successfully", function(done) {
+      conn.sobject('Account').updateMany(
+        accounts.map(function(account) {
+          return { Id : account.Id, Name : "Updated " + account.Name };
+        }),
+        function(err, rets) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(rets));
+          rets.forEach(function(ret){
+            assert.ok(ret.success);
+          });
+        }.check(done)
+      );
+    });
+
+    describe("then retrieve the accounts", function() {
+      it("sholuld return updated records", function(done) {
+        conn.sobject('Account').retrieve(accountIds, function(err, records) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(records));
+          records.forEach(function(record, i) {
+            assert.ok(record.Name === 'Updated Account #' + (i+1));
+            assert.ok(_.isObject(record.attributes));
+          });
+        }.check(done));
+      });
+    });
+  });
+
+  /**
+   *
+   */
+  describe("delete multiple accounts", function() {
+    it("should delete successfully", function(done) {
+      conn.sobject('Account').destroyMany(accountIds, function(err, rets) {
+        if (err) { throw err; }
+        assert.ok(_.isArray(rets));
+        rets.forEach(function(ret){
+          assert.ok(ret.success);
+        });
+      }.check(done));
+    });
+
+    describe("then retrieve the accounts", function() {
+      it("should not return any records", function(done) {
+        conn.sobject('Account').retrieve(accountIds, function(err, records) {
+          assert.ok(err instanceof Error);
+          assert.ok(err.errorCode === 'NOT_FOUND');
+        }.check(done));
+      });
+    });
+  });
+
+  /**
+   *
+   */
+  after(function(done) {
+    testEnv.closeConnection(conn, done);
+  });
+
+});

--- a/test/package/JSforceTestSuite/permissionsets/JSforceTestPowerUser.permissionset
+++ b/test/package/JSforceTestSuite/permissionsets/JSforceTestPowerUser.permissionset
@@ -247,6 +247,10 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
+        <name>ModifyMetadata</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
         <name>NewReportBuilder</name>
     </userPermissions>
     <userPermissions>


### PR DESCRIPTION
When `create` or `update` are called with many records, these are broken down into individual requests. Therefore there are a lot of requests in flight at once. This has caused issues for us including delays and `UNABLE_TO_LOCK_ROW` errors.

In some places in our app, we have used the Bulk API instead, but this is not ideal where an interactive/immediate response is expected. It can lead to timeouts where an error is returned to our app, but the bulk action eventually goes ahead successfully.

The [Composite Resources](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite.htm), specifically the "SObject Tree" or "SObject Collections", sound like a good solution to this, as we get to submit a number of records at once and get a quick response.

I have therefore added `createMany`, `updateMany` and `destroyMany` functions (with synonyms) to the `Connection` and `SObject` (but not `RecordReference`) classes. These take the same parameters and return the same data as the original `create`, `update` and `destroy`, but use the composite resource underneath. I have not implemented a `retrieveMany` or `upsertMany`.

Using the "SObject Collections" part of "Composite Resources" required increasing the API version to 42. I have included tests for my new functions. I have also included a tweak to a permission set in the testsuite.