### PR TITLE
Catch csv parsing errors and emit

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -118,7 +118,7 @@ Parsable.prototype.stream = function(type, options) {
   }
   if (!this._dataStream) {
     this._dataStream = new PassThrough();
-    this._parserStream = converter.parse(options);
+    this._parserStream = converter.parse(options).on('error', (error) => this.emit('error', error));
     this._parserStream.pipe(this).pipe(new PassThrough({ objectMode: true, highWaterMark: ( 500 * 1000 ) }));
   }
   return this._dataStream;


### PR DESCRIPTION
As described in this [issue](https://github.com/jsforce/jsforce/issues/764) errors during csv parsing are uncatchable by the client. Apologies for not writing a unit test for this but I'm not sure it would be possible  using the salesforce developer account and I didn't want to introduce a mocking framework to your codebase.