### PR TITLE
Use SObject collection API for query update/destroy operation

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -26,6 +26,12 @@ var defaults = {
   version: "42.0"
 };
 
+/*
+ * Constant of maximum records num in DML operation (update/delete)
+ */
+var MAX_DML_COUNT = 200;
+
+
 /**
  * Connection class to keep the API session information and manage requests
  *
@@ -680,7 +686,8 @@ Connection.prototype._toRecordResult = function(id, err) {
  * @param {String} type - SObject Type
  * @param {Object|Array.<Object>} records - A record or array of records to create
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when records goes over the max num of collection API (=200), records are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -692,7 +699,8 @@ Connection.prototype._toRecordResult = function(id, err) {
  * @param {String} type - SObject Type
  * @param {Record|Array.<Record>} records - A record or array of records to create
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when records goes over the max num of collection API (=200), records are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -766,6 +774,14 @@ Connection.prototype._createMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
+  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+    var self = this;
+    return self._createMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
+      return self._createMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+        return rets1.concat(rets2);
+      });
+    });
+  }
   records = _.map(records, function(record) {
     var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
     if (!sobjectType) {
@@ -797,7 +813,8 @@ Connection.prototype._createMany = function(type, records, options) {
  * @param {String} type - SObject Type
  * @param {Record|Array.<Record>} records - A record or array of records to update
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when records goes over the max num of collection API (=200), records are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -876,6 +893,14 @@ Connection.prototype._updateMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
+  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+    var self = this;
+    return self._updateMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
+      return self._updateMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+        return rets1.concat(rets2);
+      });
+    });
+  }
   records = _.map(records, function(record) {
     var id = record.Id;
     if (!id) {
@@ -913,7 +938,7 @@ Connection.prototype._updateMany = function(type, records, options) {
  * @param {Record|Array.<Record>} records - Record or array of records to upsert
  * @param {String} extIdField - External ID field name
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -978,7 +1003,8 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
  * @param {String} type - SObject Type
  * @param {String|Array.<String>} ids - A ID or array of IDs to delete
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when ids goes over the max num of collection API (=200), ids are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -990,7 +1016,8 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
  * @param {String} type - SObject Type
  * @param {String|Array.<String>} ids - A ID or array of IDs to delete
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when ids goes over the max num of collection API (=200), ids are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -1002,7 +1029,8 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
  * @param {String} type - SObject Type
  * @param {String|Array.<String>} ids - A ID or array of IDs to delete
  * @param {Object} [options] - Options for rest api.
- * @param {Array.<String>} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allOrNone] - If true, any failed records in a call cause all changes for the call to be rolled back
+ * @param {Boolean} [options.allowRecursive] - If true, when ids goes over the max num of collection API (=200), ids are divided into several chunks and requested recursively.
  * @param {Object} [options.headers] - Additional HTTP request headers sent in retrieve request
  * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback
  * @returns {Promise.<RecordResult|Array.<RecordResult>>}
@@ -1056,10 +1084,19 @@ Connection.prototype._destroyParallel = function(type, ids, options) {
   );
 };
 
+
 /** @private */
 Connection.prototype._destroyMany = function(type, ids, options) {
   if (ids.length === 0) {
     return Promise.resolve([]);
+  }
+  if (ids.length > MAX_DML_COUNT && options.allowRecursive) {
+    var self = this;
+    return self._destroyMany(type, ids.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
+      return self._destroyMany(type, ids.slice(MAX_DML_COUNT), options).then(function(rets2) {
+        return rets1.concat(rets2);
+      });
+    });
   }
   var url = [ this._baseUrl(), "composite", "sobjects?ids=" ].join('/') + ids.join(',');
   if (options.allOrNone) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -629,7 +629,7 @@ Query.prototype.filter = RecordStream.prototype.map;
  * @method Query#delete
  * @param {String} [type] - SObject type. Required for SOQL based query object.
  * @param {Callback.<Array.<RecordResult>>} [callback] - Callback function
- * @returns {Bulk~Batch}
+ * @returns {Promise.<Array.<RecordResult>>}
  */
 /**
  * Synonym of Query#destroy()
@@ -637,7 +637,7 @@ Query.prototype.filter = RecordStream.prototype.map;
  * @method Query#del
  * @param {String} [type] - SObject type. Required for SOQL based query object.
  * @param {Callback.<Array.<RecordResult>>} [callback] - Callback function
- * @returns {Bulk~Batch}
+ * @returns {Promise.<Array.<RecordResult>>}
  */
 /**
  * Bulk delete queried records
@@ -658,17 +658,43 @@ Query.prototype.destroy = function(type, callback) {
   if (!type) {
     throw new Error("SOQL based query needs SObject type information to bulk delete.");
   }
-  var batch = this._conn.sobject(type).deleteBulk();
-  var deferred = Promise.defer();
-  var handleError = function(err) {
-    if (err.name === 'ClientInputError') { deferred.resolve([]); } // if batch input receives no records
-    else { deferred.reject(err); }
-  };
-  this.on('error', handleError)
-    .pipe(batch)
-    .on('response', function(res) { deferred.resolve(res); })
-    .on('error', handleError);
-  return deferred.promise.thenCall(callback);
+  // Set the threshold number to pass to bulk API
+  // whether the connection version supports SObject collection API or not
+  var thresholdNum = this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2;
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    var records = [];
+    var batch = null;
+    var handleRecord = function(record) {
+      if (batch) {
+        batch.write(record);
+      } else {
+        records.push(record);
+        if (records.length >= thresholdNum) {
+          // Use bulk delete instead of SObject REST API
+          batch =
+            self._conn.sobject(type).deleteBulk()
+              .on('response', resolve)
+              .on('error', reject);
+          records.forEach(function(record) {
+            batch.write(record);
+          });
+          records = [];
+        }
+      }
+    };
+    var handleEnd = function() {
+      if (batch) {
+        batch.end();
+      } else {
+        var ids = records.map(function (record) { return record.Id; });
+        self._conn.sobject(type).destroy(ids).then(resolve, reject);
+      }
+    };
+    self.on('record', handleRecord)
+      .on('end', handleEnd)
+      .on('error', reject);
+  }).thenCall(callback);
 };
 
 /**
@@ -689,19 +715,44 @@ Query.prototype.update = function(mapping, type, callback) {
     throw new Error("SOQL based query needs SObject type information to bulk update.");
   }
   var updateStream = _.isFunction(mapping) ? RecordStream.map(mapping) : RecordStream.recordMapStream(mapping);
-  var batch = this._conn.sobject(type).updateBulk();
-  var deferred = Promise.defer();
-  var handleError = function(err) {
-    if (err.name === 'ClientInputError') { deferred.resolve([]); } // if batch input receives no records
-    else { deferred.reject(err); }
-  };
-  this.on('error', handleError)
-    .pipe(updateStream)
-    .on('error', handleError)
-    .pipe(batch)
-    .on('response', function(res) { deferred.resolve(res); })
-    .on('error', handleError);
-  return deferred.promise.thenCall(callback);
+  // Set the threshold number to pass to bulk API
+  // whether the connection version supports SObject collection API or not
+  var thresholdNum = this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2;
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    var records = [];
+    var batch = null;
+    var handleRecord = function(record) {
+      if (batch) {
+        batch.write(record);
+      } else {
+        records.push(record);
+        if (records.length >= thresholdNum) {
+          // Use bulk update instead of SObject REST API
+          batch =
+            self._conn.sobject(type).updateBulk()
+              .on('response', resolve)
+              .on('error', reject);
+          records.forEach(function(record) {
+            batch.write(record);
+          });
+          records = [];
+        }
+      }
+    };
+    var handleEnd = function() {
+      if (batch) {
+        batch.end();
+      } else {
+        self._conn.sobject(type).update(records).then(resolve, reject);
+      }
+    };
+    self.on('error', reject)
+      .pipe(updateStream)
+      .on('record', handleRecord)
+      .on('end', handleEnd)
+      .on('error', reject);
+  }).thenCall(callback);
 };
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -691,7 +691,7 @@ Query.prototype.destroy = function(type, callback) {
         self._conn.sobject(type).destroy(ids).then(resolve, reject);
       }
     };
-    self.on('record', handleRecord)
+    self.on('data', handleRecord)
       .on('end', handleEnd)
       .on('error', reject);
   }).thenCall(callback);
@@ -749,7 +749,7 @@ Query.prototype.update = function(mapping, type, callback) {
     };
     self.on('error', reject)
       .pipe(updateStream)
-      .on('record', handleRecord)
+      .on('data', handleRecord)
       .on('end', handleEnd)
       .on('error', reject);
   }).thenCall(callback);

--- a/lib/query.js
+++ b/lib/query.js
@@ -624,9 +624,9 @@ Query.prototype.map = RecordStream.prototype.map;
 Query.prototype.filter = RecordStream.prototype.map;
 
 /*
- * Constant of maximum records num in DML operation (update/delete)
+ * Default threshold num of bulk API switching
  */
-var MAX_DML_COUNT = 200;
+var DEFAULT_BULK_THRESHOLD = 200;
 
 /**
  * Synonym of Query#destroy()
@@ -673,13 +673,13 @@ Query.prototype.destroy = function(type, options, callback) {
     throw new Error("SOQL based query needs SObject type information to bulk delete.");
   }
   // Set the threshold number to pass to bulk API
-  // whether the connection version supports SObject collection API or not
   var thresholdNum =
     options.allowBulk === false ?
       -1 :
     typeof options.bulkThreshold === 'number' ?
       options.bulkThreshold :
-      (this._conn._ensureVersion(42) ? MAX_DML_COUNT : this._conn.maxRequest / 2);
+      // determine threshold if the connection version supports SObject collection API or not
+      (this._conn._ensureVersion(42) ? DEFAULT_BULK_THRESHOLD : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];
@@ -694,7 +694,7 @@ Query.prototype.destroy = function(type, options, callback) {
         batch.write(record);
       } else {
         records.push(record);
-        if (thresholdNum < 0 || records.length >= thresholdNum) {
+        if (thresholdNum < 0 || records.length > thresholdNum) {
           // Use bulk delete instead of SObject REST API
           batch =
             self._conn.sobject(type).deleteBulk()
@@ -712,7 +712,7 @@ Query.prototype.destroy = function(type, options, callback) {
         batch.end();
       } else {
         var ids = records.map(function (record) { return record.Id; });
-        self._conn.sobject(type).destroy(ids).then(resolve, reject);
+        self._conn.sobject(type).destroy(ids, { allowRecursive: true }).then(resolve, reject);
       }
     };
     self.on('data', handleRecord)
@@ -749,13 +749,13 @@ Query.prototype.update = function(mapping, type, options, callback) {
   }
   var updateStream = _.isFunction(mapping) ? RecordStream.map(mapping) : RecordStream.recordMapStream(mapping);
   // Set the threshold number to pass to bulk API
-  // whether the connection version supports SObject collection API or not
   var thresholdNum =
     options.allowBulk === false ?
       -1 :
     typeof options.bulkThreshold === 'number' ?
       options.bulkThreshold :
-      (this._conn._ensureVersion(42) ? MAX_DML_COUNT : this._conn.maxRequest / 2);
+      // determine threshold if the connection version supports SObject collection API or not
+      (this._conn._ensureVersion(42) ? DEFAULT_BULK_THRESHOLD : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];
@@ -765,7 +765,7 @@ Query.prototype.update = function(mapping, type, options, callback) {
         batch.write(record);
       } else {
         records.push(record);
-        if (thresholdNum < 0 || records.length >= thresholdNum) {
+        if (thresholdNum < 0 || records.length > thresholdNum) {
           // Use bulk update instead of SObject REST API
           batch =
             self._conn.sobject(type).updateBulk()
@@ -782,7 +782,7 @@ Query.prototype.update = function(mapping, type, options, callback) {
       if (batch) {
         batch.end();
       } else {
-        self._conn.sobject(type).update(records).then(resolve, reject);
+        self._conn.sobject(type).update(records, { allowRecursive: true }).then(resolve, reject);
       }
     };
     self.on('error', reject)

--- a/lib/query.js
+++ b/lib/query.js
@@ -623,6 +623,11 @@ Query.prototype.map = RecordStream.prototype.map;
  */
 Query.prototype.filter = RecordStream.prototype.map;
 
+/*
+ * Constant of maximum records num in DML operation (update/delete)
+ */
+var MAX_DML_COUNT = 200;
+
 /**
  * Synonym of Query#destroy()
  *
@@ -674,7 +679,7 @@ Query.prototype.destroy = function(type, options, callback) {
       -1 :
     typeof options.bulkThreshold === 'number' ?
       options.bulkThreshold :
-      (this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2);
+      (this._conn._ensureVersion(42) ? MAX_DML_COUNT : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];
@@ -750,7 +755,7 @@ Query.prototype.update = function(mapping, type, options, callback) {
       -1 :
     typeof options.bulkThreshold === 'number' ?
       options.bulkThreshold :
-      (this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2);
+      (this._conn._ensureVersion(42) ? MAX_DML_COUNT : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];

--- a/lib/query.js
+++ b/lib/query.js
@@ -640,37 +640,56 @@ Query.prototype.filter = RecordStream.prototype.map;
  * @returns {Promise.<Array.<RecordResult>>}
  */
 /**
- * Bulk delete queried records
+ * Delete queried records
  *
  * @method Query#destroy
  * @param {String} [type] - SObject type. Required for SOQL based query object.
+ * @param {Object} [options] - Mass delete operation options
+ * @param {Boolean} [options.allowBulk] - Allow switching to Bulk API when the num of queried records reached to certain threshold. Default is true.
+ * @param {Number} [options.bulkThreshold] - Threshold num to switch to use Bulk API instead of usual `SObject#delete()` call. Default value is 200 after API ver 42.0, and 0.5 * `maxRequest` before API ver 42.0.
  * @param {Callback.<Array.<RecordResult>>} [callback] - Callback function
  * @returns {Promise.<Array.<RecordResult>>}
  */
 Query.prototype["delete"] =
 Query.prototype.del =
-Query.prototype.destroy = function(type, callback) {
+Query.prototype.destroy = function(type, options, callback) {
   if (typeof type === 'function') {
     callback = type;
+    options = {};
+    type = null;
+  } else if (typeof type === 'object' && type !== null) {
+    callback = options;
+    options = type;
     type = null;
   }
+  options = options || {};
   type = type || (this._config && this._config.table);
   if (!type) {
     throw new Error("SOQL based query needs SObject type information to bulk delete.");
   }
   // Set the threshold number to pass to bulk API
   // whether the connection version supports SObject collection API or not
-  var thresholdNum = this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2;
+  var thresholdNum =
+    options.allowBulk === false ?
+      -1 :
+    typeof options.bulkThreshold === 'number' ?
+      options.bulkThreshold :
+      (this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];
     var batch = null;
-    var handleRecord = function(record) {
+    var handleRecord = function(rec) {
+      if (!rec.Id) {
+        self.emit('error', new Error('Queried record does not include Salesforce record ID.'))
+        return;
+      }
+      var record = { Id: rec.Id };
       if (batch) {
         batch.write(record);
       } else {
         records.push(record);
-        if (records.length >= thresholdNum) {
+        if (thresholdNum < 0 || records.length >= thresholdNum) {
           // Use bulk delete instead of SObject REST API
           batch =
             self._conn.sobject(type).deleteBulk()
@@ -698,18 +717,27 @@ Query.prototype.destroy = function(type, callback) {
 };
 
 /**
- * Bulk update queried records, using given mapping function/object
+ * Update queried records, using given mapping function/object
  *
  * @param {Record|RecordMapFunction} mapping - Mapping record or record mapping function
  * @param {String} [type] - SObject type. Required for SOQL based query object.
+ * @param {Object} [options] - Mass update operation options
+ * @param {Boolean} [options.allowBulk] - Allow switching to Bulk API when the num of queried records reached to certain threshold. Default is true.
+ * @param {Number} [options.bulkThreshold] - Threshold num to switch to use Bulk API instead of usual `SObject#delete()` call. Default value is 200 after API ver 42.0, and 0.5 * `maxRequest` before API ver 42.0.
  * @param {Callback.<Array.<RecordResult>>} [callback] - Callback function
  * @returns {Promise.<Array.<RecordResult>>}
  */
-Query.prototype.update = function(mapping, type, callback) {
+Query.prototype.update = function(mapping, type, options, callback) {
   if (typeof type === 'function') {
     callback = type;
+    options = {};
+    type = null;
+  } else if (typeof type === 'object' && type !== null) {
+    callback = options;
+    options = type;
     type = null;
   }
+  options = options || {};
   type = type || (this._config && this._config.table);
   if (!type) {
     throw new Error("SOQL based query needs SObject type information to bulk update.");
@@ -717,7 +745,12 @@ Query.prototype.update = function(mapping, type, callback) {
   var updateStream = _.isFunction(mapping) ? RecordStream.map(mapping) : RecordStream.recordMapStream(mapping);
   // Set the threshold number to pass to bulk API
   // whether the connection version supports SObject collection API or not
-  var thresholdNum = this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2;
+  var thresholdNum =
+    options.allowBulk === false ?
+      -1 :
+    typeof options.bulkThreshold === 'number' ?
+      options.bulkThreshold :
+      (this._conn._ensureVersion(42) ? 200 : this._conn.maxRequest / 2);
   var self = this;
   return new Promise(function(resolve, reject) {
     var records = [];
@@ -727,7 +760,7 @@ Query.prototype.update = function(mapping, type, callback) {
         batch.write(record);
       } else {
         records.push(record);
-        if (records.length >= thresholdNum) {
+        if (thresholdNum < 0 || records.length >= thresholdNum) {
           // Use bulk update instead of SObject REST API
           batch =
             self._conn.sobject(type).updateBulk()

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -63,32 +63,6 @@ SObject.prototype.create = function(records, options, callback) {
 };
 
 /**
- * Synonym of SObject#createMany()
- *
- * @method SObject#insertMany
- * @param {Record|Array.<Record>} records - A record or array of records to create
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-/**
- * Create multiple records with fewer round trips
- *
- * @method SObject#createMany
- * @param {Record|Array.<Record>} records - A record or array of records to create
- * @param {Object} [options] - Options for rest api.
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-SObject.prototype.insertMany =
-SObject.prototype.createMany = function(records, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  return this._conn.createMany(this.type, records, options, callback);
-};
-
-/**
  * Retrieve specified records
  *
  * @param {String|Array.<String>} ids - A record ID or array of record IDs
@@ -118,22 +92,6 @@ SObject.prototype.update = function(records, options, callback) {
     options = {};
   }
   return this._conn.update(this.type, records, options, callback);
-};
-
-/**
- * Update multiple records with fewer round trips
- *
- * @param {Record|Array.<Record>} records - A record or array of records to update
- * @param {Object} [options] - Options for rest api.
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-SObject.prototype.updateMany = function(records, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  return this._conn.updateMany(this.type, records, options, callback);
 };
 
 /**
@@ -186,41 +144,6 @@ SObject.prototype.destroy = function(ids, options, callback) {
     options = {};
   }
   return this._conn.destroy(this.type, ids, options, callback);
-};
-
-/**
- * Synonym of SObject#destroyMany()
- *
- * @method SObject#deleteMany
- * @param {String|Array.<String>} ids - A ID or array of IDs to delete
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-/**
- * Synonym of SObject#destroyMany()
- *
- * @method SObject#delMany
- * @param {String|Array.<String>} ids - A ID or array of IDs to delete
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-/**
- * Delete multiple records with fewer round trips
- *
- * @method SObject#destroyMany
- * @param {String|Array.<String>} ids - A ID or array of IDs to delete
- * @param {Object} [options] - Options for rest api.
- * @param {Callback.<RecordResult|Array.<RecordResult>>} [callback] - Callback function
- * @returns {Promise.<RecordResult|Array.<RecordResult>>}
- */
-SObject.prototype["deleteMany"] =
-SObject.prototype.delMany =
-SObject.prototype.destroyMany = function(ids, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  return this._conn.destroyMany(this.type, ids, options, callback);
 };
 
 /**

--- a/test/bulk.test.js
+++ b/test/bulk.test.js
@@ -295,6 +295,8 @@ if (TestEnv.isNodeJS) {
   });
 
 /*------------------------------------------------------------------------*/
+  // The num should be more than 200 which fallback from SObject collection API
+  var bulkAccountNum = 250;
 
   /**
    *
@@ -302,7 +304,7 @@ if (TestEnv.isNodeJS) {
   describe("bulk update using Query#update", function() {
     before(function(done) {
       var records = [];
-      for (var i=0; i<200; i++) {
+      for (var i=0; i<bulkAccountNum; i++) {
         records.push({
           Name: 'New Bulk Account #'+(i+1),
           BillingState: 'CA',
@@ -321,7 +323,7 @@ if (TestEnv.isNodeJS) {
           }, function(err, rets) {
             if (err) { throw err; }
             assert.ok(_.isArray(rets));
-            assert.ok(rets.length === 200);
+            assert.ok(rets.length === bulkAccountNum);
             for (var i=0; i<rets.length; i++) {
               var ret = rets[i];
               assert.ok(_.isString(ret.id));
@@ -336,9 +338,9 @@ if (TestEnv.isNodeJS) {
             .find({ Name : { $like : 'New Bulk Account%' }}, 'Id, Name, BillingState', function(err, records) {
               if (err) { throw err; }
               assert.ok(_.isArray(records));
-              assert.ok(records.length === 200);
+              assert.ok(records.length === bulkAccountNum);
               var record;
-              for (var i=0; i<200; i++) {
+              for (var i=0; i<records.length; i++) {
                 record = records[i];
                 assert.ok(_.isString(record.Id));
                 assert.ok(/\(Updated\)$/.test(record.Name));
@@ -374,7 +376,7 @@ if (TestEnv.isNodeJS) {
           .destroy(function(err, rets) {
             if (err) { throw err; }
             assert.ok(_.isArray(rets));
-            assert.ok(rets.length === 200);
+            assert.ok(rets.length === bulkAccountNum);
             for (var i=0; i<rets.length; i++) {
               var ret = rets[i];
               assert.ok(_.isString(ret.id));

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -226,6 +226,110 @@ describe("query", function() {
     });
   });
 
+/*------------------------------------------------------------------------*/
+  // The num should be less than 200, not to fallback to bulk API
+  var accountNum = 20;
+
+  /**
+   *
+   */
+  describe("update queried records using Query#update", function() {
+    before(function(done) {
+      var records = [];
+      for (var i=0; i<accountNum; i++) {
+        records.push({
+          Name: 'New Bulk Account #'+(i+1),
+          BillingState: 'CA',
+          NumberOfEmployees: 300 * (i+1)
+        });
+      }
+      conn.sobject("Account").create(records, done);
+    });
+
+    it("should return updated status", function(done) {
+      conn.sobject('Account')
+          .find({ Name : { $like : 'New Bulk Account%' }})
+          .update({
+            Name : '${Name} (Updated)',
+            BillingState: null
+          }, function(err, rets) {
+            if (err) { throw err; }
+            assert.ok(_.isArray(rets));
+            assert.ok(rets.length === accountNum);
+            for (var i=0; i<rets.length; i++) {
+              var ret = rets[i];
+              assert.ok(_.isString(ret.id));
+              assert.ok(ret.success === true);
+            }
+          }.check(done));
+    });
+
+    describe("then query updated records", function() {
+      it("should return updated records", function(done) {
+        conn.sobject('Account')
+            .find({ Name : { $like : 'New Bulk Account%' }}, 'Id, Name, BillingState', function(err, records) {
+              if (err) { throw err; }
+              assert.ok(_.isArray(records));
+              assert.ok(records.length === accountNum);
+              var record;
+              for (var i=0; i<records.length; i++) {
+                record = records[i];
+                assert.ok(_.isString(record.Id));
+                assert.ok(/\(Updated\)$/.test(record.Name));
+                assert.ok(record.BillingState === null);
+              }
+            }.check(done));
+      });
+    });
+  });
+
+  describe("update queried records using Query#update, for unmatching query", function() {
+    it("should return empty array records", function(done) {
+      conn.sobject('Account')
+          .find({ CreatedDate : { $lt : new sf.Date('1970-01-01T00:00:00Z') }}) // should not match any records
+          .update({
+            Name: '${Name} (Updated)',
+            BillingState: null
+          }, function(err, rets) {
+            if (err) { throw err; }
+            assert.ok(_.isArray(rets));
+            assert.ok(rets.length === 0);
+          }.check(done));
+    });
+  });
+
+  /**
+   *
+   */
+  describe("delete queried records using Query#destroy", function() {
+    it("should return deleted status", function(done) {
+      conn.sobject('Account')
+          .find({ Name : { $like : 'New Bulk Account%' }})
+          .destroy(function(err, rets) {
+            if (err) { throw err; }
+            assert.ok(_.isArray(rets));
+            assert.ok(rets.length === accountNum);
+            for (var i=0; i<rets.length; i++) {
+              var ret = rets[i];
+              assert.ok(_.isString(ret.id));
+              assert.ok(ret.success === true);
+            }
+          }.check(done));
+    });
+  });
+
+  describe("delete queried records using Query#destroy, for unmatching query", function() {
+    it("should return empty array records", function(done) {
+      conn.sobject('Account')
+          .find({ CreatedDate : { $lt : new sf.Date('1970-01-01T00:00:00Z') }})
+          .destroy(function(err, rets) {
+            if (err) { throw err; }
+            assert.ok(_.isArray(rets));
+            assert.ok(rets.length === 0);
+          }.check(done));
+    });
+  });
+
   /**
    *
    */


### PR DESCRIPTION
As far as the queried record num is not so big as the given threshold, use collection API instead of bulk API, which is a little heavy and has always delay of polling.
The threshold value can be modified by passing options.