### PR TITLE
Allow auto client registration for default

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -297,8 +297,8 @@ function register(clientName, clientConfig, callback) {
   }
 
   var prompts = {
-    "clientId": "Input client ID (consumer key) : ",
-    "clientSecret": "Input client secret (consumer secret) : ",
+    "clientId": "Input client ID : ",
+    "clientSecret": "Input client secret (optional) : ",
     "redirectUri": "Input redirect URI : ",
     "loginUrl": "Input login URL (default is https://login.salesforce.com) : "
   };

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -209,9 +209,9 @@ function authorize(clientName, callback) {
   clientName = clientName || 'default';
   var oauth2Config = registry.getClient(clientName);
   if (!oauth2Config || !oauth2Config.clientId) {
-    if (clientName === 'default') {
-      print('No default client information registered. Downloading JSforce default client information...');
-      return downloadDefaultClientInfo(callback);
+    if (clientName === 'default' || clientName === 'sandbox') {
+      print('No client information registered. Downloading JSforce default client information...');
+      return downloadDefaultClientInfo(clientName, callback);
     }
     return callback(new Error("No OAuth2 client information registered : '"+clientName+"'. Please register client info first."));
   }
@@ -247,14 +247,17 @@ function authorize(clientName, callback) {
 /**
  * @private
  */
-function downloadDefaultClientInfo(callback) {
+function downloadDefaultClientInfo(clientName, callback) {
   var configUrl = 'https://jsforce.github.io/client-config/default.json';
   request(configUrl, function(err, res) {
     if (err) { return callback(err); }
-    const clientConfig = JSON.parse(res.body);
-    registry.registerClient('default', clientConfig);
+    var clientConfig = JSON.parse(res.body);
+    if (clientName === 'sandbox') {
+      clientConfig.loginUrl = 'https://test.salesforce.com';
+    }
+    registry.registerClient(clientName, clientConfig);
     print("Client information downloaded successfully.");
-    authorize('default', callback);
+    authorize(clientName, callback);
   });
 }
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -8,9 +8,12 @@
 
 var http = require('http'),
     url = require('url'),
+    crypto = require('crypto'),
     openUrl = require('opn'),
     commander = require('commander'),
     coprompt = require('co-prompt'),
+    request = require('request'),
+    base64url = require('base64-url'),
     Repl = require('./repl'),
     jsforce = require('../jsforce'),
     registry = jsforce.registry,
@@ -205,12 +208,18 @@ function disconnect(name) {
 function authorize(clientName, callback) {
   clientName = clientName || 'default';
   var oauth2Config = registry.getClient(clientName);
-  if (!oauth2Config || !oauth2Config.clientId || !oauth2Config.clientSecret) {
+  if (!oauth2Config || !oauth2Config.clientId) {
+    if (clientName === 'default') {
+      print('No default client information registered. Downloading JSforce default client information...');
+      return downloadDefaultClientInfo(callback);
+    }
     return callback(new Error("No OAuth2 client information registered : '"+clientName+"'. Please register client info first."));
   }
   var oauth2 = new jsforce.OAuth2(oauth2Config);
-  var state = Math.random().toString(36).substring(2);
-  var authzUrl = oauth2.getAuthorizationUrl({ state: state });
+  var verifier = base64url.encode(crypto.randomBytes(32));
+  var challenge = base64url.encode(crypto.createHash('sha256').update(verifier).digest());
+  var state = base64url.encode(crypto.randomBytes(32));
+  var authzUrl = oauth2.getAuthorizationUrl({ code_challenge: challenge, state: state });
   print('Opening authorization page in browser...');
   print('URL: ' + authzUrl);
   openUrl(authzUrl);
@@ -224,7 +233,7 @@ function authorize(clientName, callback) {
       return callback(new Error('Invalid state parameter returned.'));
     }
     print('Received authorization code. Please close the opened browser window.');
-    conn.authorize(params.code).then(function(res) {
+    conn.authorize(params.code, { code_verifier: verifier }).then(function(res) {
       print('Authorized. Fetching user info...');
       return conn.identity();
     }).then(function(identity) {
@@ -232,6 +241,20 @@ function authorize(clientName, callback) {
       connName = identity.username;
       saveCurrentConnection();
     }).thenCall(callback);
+  });
+}
+
+/**
+ * @private
+ */
+function downloadDefaultClientInfo(callback) {
+  var configUrl = 'https://jsforce.github.io/client-config/default.json';
+  request(configUrl, function(err, res) {
+    if (err) { return callback(err); }
+    const clientConfig = JSON.parse(res.body);
+    registry.registerClient('default', clientConfig);
+    print("Client information downloaded successfully.");
+    authorize('default', callback);
   });
 }
 
@@ -279,37 +302,35 @@ function register(clientName, clientConfig, callback) {
     "redirectUri": "Input redirect URI : ",
     "loginUrl": "Input login URL (default is https://login.salesforce.com) : "
   };
-  Promise.resolve().then(function() {
-    var deferred = Promise.defer();
+  new Promise(function(resolve, reject) {
     if (registry.getClient(clientName)) {
       var msg = "Client '"+clientName+"' is already registered. Are you sure you want to override ? [yN] : ";
       promptConfirm(msg, function(err, ok) {
         if (ok) {
-          deferred.resolve();
+          resolve();
         } else {
-          deferred.reject(new Error('Registration canceled.'));
+          reject(new Error('Registration canceled.'));
         }
       });
     } else {
-      deferred.resolve();
+      resolve();
     }
-    return deferred.promise;
   })
   .then(function() {
     return Object.keys(prompts).reduce(function(promise, name) {
       return promise.then(function() {
         var message = prompts[name];
-        var deferred = Promise.defer();
-        if (!clientConfig[name]) {
-          promptMessage(message, function(err, value) {
-            if (err) { return deferred.reject(err); }
-            if (value) { clientConfig[name] = value; }
-            deferred.resolve();
-          });
-        } else {
-          deferred.resolve();
-        }
-        return deferred.promise;
+        return new Promise(function(resolve, reject) {
+          if (!clientConfig[name]) {
+            promptMessage(message, function(err, value) {
+              if (err) { return reject(err); }
+              if (value) { clientConfig[name] = value; }
+              resolve();
+            });
+          } else {
+            resolve();
+          }
+        });
       });
     }, Promise.resolve());
   }).then(function() {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jsforce": "./bin/jsforce"
   },
   "dependencies": {
+    "base64-url": "^2.2.0",
     "co-prompt": "^1.0.0",
     "coffeescript": "^1.10.0",
     "commander": "^2.9.0",


### PR DESCRIPTION
As JSforce supports OAuth2 PKCE and client secret information is not necessary for public client, the CLI (REPL) does not require any client secret information.

So we put the default OAuth2 client information on the public URL with its client id and redirect URL, and if the CLI cannot find the client information it will automatically download the info and register as the default.
As a result, new connected app registration is not required for JSforce CLI users.