### PR TITLE
Update checkDeployStatus response parameter "runTestsEnabled"

### DIFF
--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -543,6 +543,7 @@ Metadata.prototype.checkDeployStatus = function(id, includeDetails, callback) {
     res.done = res.done === 'true';
     res.success = res.success === 'true';
     res.checkOnly = res.checkOnly === 'true';
+    res.runTestsEnabled = res.runTestsEnabled === 'true';
     if (res.ignoreWarnings) {
       res.ignoreWarnings = res.ignoreWarnings === 'true';
     }


### PR DESCRIPTION
Metadata.checkDeployStatus response parameter **runTestsEnabled** does not match other response parameter types. **runTestsEnabled** is returned as a string type, whereas other parameters are returned as boolean type.

Example:
```   
  console.log('Checking status for Deploy Request: ' + id);
  let conn = new jsforce.Connection({
    instanceUrl: oauth2.instanceUrl,
    accessToken: oauth2.accessToken,
  });
  return await conn.metadata.checkDeployStatus(id, true);
```
![screen shot 2018-08-06 at 10 56 51 am](https://user-images.githubusercontent.com/7391400/43732806-74de83de-9967-11e8-8ff3-f2cc2fd8cdca.png)

