### PR TITLE
FIX new Buffer()

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -252,7 +252,7 @@ function parseSignedRequest(sr) {
       return JSON.parse(sr);
     } else { // might be original base64-encoded signed request
       var msg = sr.split('.').pop(); // retrieve latter part
-      var json = new Buffer(msg, 'base64').toString('utf-8');
+      var json = Buffer.from(msg, 'base64').toString('utf-8');
       return JSON.parse(json);
     }
     return null;


### PR DESCRIPTION
Now `new Buffer()` is  deprecated.

[buffer](https://nodejs.org/api/buffer.html#buffer_new_buffer_array)

> Stability: 0 - Deprecated: Use Buffer.from(array) instead.

