### PR TITLE
Fix multiple Replay extensions' interference

### DIFF
--- a/lib/api/streaming-extension.js
+++ b/lib/api/streaming-extension.js
@@ -118,7 +118,7 @@ StreamingExtension.Replay = function(channel, replayId) {
   }
   
   this.outgoing = function(message, callback) {
-    if (message.channel === '/meta/subscribe') {
+    if (message.channel === '/meta/subscribe' && message.subscription === _channel) {
       if (_extensionEnabled) {
         if (!message.ext) { message.ext = {}; }
 


### PR DESCRIPTION
This PR adds an extra check to prevent the final extension in the pipeline from overwriting the Replay ID Mapping when it is not a subscription for the relevant channel.

This is a proposed fix for #814.