### PR TITLE
Adds support for SOAP Headers

### DIFF
--- a/lib/api/soap.js
+++ b/lib/api/soap.js
@@ -33,7 +33,7 @@ SoapApi.prototype._invoke = function(method, message, schema, soapHeaders, callb
     xmlns: "urn:partner.soap.sforce.com",
     endpointUrl: this._conn.instanceUrl + "/services/Soap/u/" + this._conn.version
   });
-  return soapEndpoint.invoke(method, message, soapHeaders, { result: schema }).then(function(res) {
+  return soapEndpoint.invoke(method, message, { result: schema }, soapHeaders).then(function(res) {
     return res.result;
   }).thenCall(callback);
 };

--- a/lib/api/soap.js
+++ b/lib/api/soap.js
@@ -23,12 +23,17 @@ var SoapApi = module.exports = function(conn) {
  * Call SOAP Api (Partner) endpoint
  * @private
  */
-SoapApi.prototype._invoke = function(method, message, schema, callback) {
+SoapApi.prototype._invoke = function(method, message, schema, soapHeaders, callback) {
+  if (typeof soapHeaders === 'function') {
+    callback = soapHeaders;
+    soapHeaders = null;
+  }
+
   var soapEndpoint = new SOAP(this._conn, {
     xmlns: "urn:partner.soap.sforce.com",
     endpointUrl: this._conn.instanceUrl + "/services/Soap/u/" + this._conn.version
   });
-  return soapEndpoint.invoke(method, message, { result: schema }).then(function(res) {
+  return soapEndpoint.invoke(method, message, soapHeaders, { result: schema }).then(function(res) {
     return res.result;
   }).thenCall(callback);
 };
@@ -303,14 +308,14 @@ SoapApi.prototype.resetPassword = function(userId, callback) {
  * @param {Callback.<SoapApi~SaveResult>} [callback] - Callback function
  * @returns {Promise.<SoapApi~SaveResult>}
  */
-SoapApi.prototype.create = function(sObjects, callback) {
+SoapApi.prototype.create = function(sObjects, soapHeaders, callback) {
   var schema = _.isArray(sObjects) ? [ Schemas.SaveResult ] : Schemas.SaveResult;
   var args = {
     '@xmlns' : 'urn:partner.soap.sforce.com',
     '@xmlns:ns1' : 'sobject.partner.soap.sforce.com',
     'ns1:sObjects' : sObjects
   };
-  return this._invoke("create", args, schema, callback);
+  return this._invoke("create", args, schema, soapHeaders, callback);
 };
 
 /**
@@ -320,14 +325,14 @@ SoapApi.prototype.create = function(sObjects, callback) {
  * @param {Callback.<SoapApi~SaveResult>} [callback] - Callback function
  * @returns {Promise.<SoapApi~SaveResult>}
  */
-SoapApi.prototype.update = function(sObjects, callback) {
+SoapApi.prototype.update = function(sObjects, soapHeaders, callback) {
   var schema = _.isArray(sObjects) ? [ Schemas.SaveResult ] : Schemas.SaveResult;
   var args = {
     '@xmlns' : 'urn:partner.soap.sforce.com',
     '@xmlns:ns1' : 'sobject.partner.soap.sforce.com',
     'ns1:sObjects' : sObjects
   };
-  return this._invoke("update", args, schema, callback);
+  return this._invoke("update", args, schema, soapHeaders, callback);
 };
 
 Schemas.SaveResult = {
@@ -343,7 +348,7 @@ Schemas.SaveResult = {
  * @param {Callback.<SoapApi~UpsertResult>} [callback] - Callback function
  * @returns {Promise.<SoapApi~UpsertResult>}
  */
-SoapApi.prototype.upsert = function(externalIdFieldName, sObjects, callback) {
+SoapApi.prototype.upsert = function(externalIdFieldName, sObjects, soapHeaders, callback) {
   var schema = _.isArray(sObjects) ? [ Schemas.UpsertResult ] : Schemas.UpsertResult;
   var args = {
     '@xmlns' : 'urn:partner.soap.sforce.com',
@@ -351,7 +356,7 @@ SoapApi.prototype.upsert = function(externalIdFieldName, sObjects, callback) {
     'ns1:externalIDFieldName' : externalIdFieldName,
     'ns1:sObjects' : sObjects
   };
-  return this._invoke("upsert", args, schema, callback);
+  return this._invoke("upsert", args, schema, soapHeaders, callback);
 };
 
 Schemas.UpsertResult = {
@@ -368,14 +373,14 @@ Schemas.UpsertResult = {
  * @param {Callback.<SoapApi~DeleteResult>} [callback] - Callback function
  * @returns {Promise.<SoapApi~DeleteResult>}
  */
-SoapApi.prototype.delete = function(ids, callback) {
+SoapApi.prototype.delete = function(ids, soapHeaders, callback) {
   var schema = _.isArray(ids) ? [ Schemas.DeleteResult ] : Schemas.DeleteResult;
   var args = {
     '@xmlns' : 'urn:partner.soap.sforce.com',
     '@xmlns:ns1' : 'sobject.partner.soap.sforce.com',
     'ns1:ids' : ids
   };
-  return this._invoke("delete", args, schema, callback);
+  return this._invoke("delete", args, schema, soapHeaders, callback);
 };
 
 Schemas.DeleteResult = {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -797,7 +797,7 @@ Connection.prototype._createParallel = function(type, records, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(null, err);
+        return self._toRecordResult(null, err);
       });
     })
   );
@@ -916,7 +916,7 @@ Connection.prototype._updateParallel = function(type, records, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(record.Id, err);
+        return self._toRecordResult(record.Id, err);
       });
     })
   );
@@ -1112,7 +1112,7 @@ Connection.prototype._destroyParallel = function(type, ids, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(id, err);
+        return self._toRecordResult(id, err);
       });
     })
   );

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -36,16 +36,24 @@ inherits(SOAP, HttpApi);
  * @param {String} method - Method name
  * @param {Object} args - Arguments for the method call
  * @param {Object} [schema] - Schema definition of response message
+ * @param {Object} [soapHeaders] - SOAP headers (https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/soap_headers.htm)
  * @param {Callback.<Object>} [callback] - Callback function
  * @returns {Promise.<Object>}
  */
-SOAP.prototype.invoke = function(method, args, schema, callback) {
+SOAP.prototype.invoke = function(method, args, schema, soapHeaders, callback) {
   if (typeof schema === 'function') {
     callback = schema;
     schema = null;
   }
+  if (typeof soapHeaders === 'function') {
+    callback = soapHeaders;
+    soapHeaders = null;
+  }
   var message = {};
   message[method] = args;
+  if (soapHeaders) {
+    message['soapHeaders'] = soapHeaders;
+  }
   return this.request({
     method: 'POST',
     url: this._endpointUrl,
@@ -183,7 +191,9 @@ function toXML(name, value) {
  * @private
  */
 SOAP.prototype._createEnvelope = function(message) {
-  var header = {};
+  var header = _.extend({}, message.soapHeaders);
+  delete message.soapHeaders;
+
   var conn = this._conn;
   if (conn.accessToken) {
     header.SessionHeader = { sessionId: this._conn.accessToken };


### PR DESCRIPTION
The Salesforce API provides SOAP headers to client applications. https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/soap_headers.htm

Currently only `CallOptions` are supported, and it's not possible to set header like `DuplicateRuleHeader`. This PR adds a flexible way of adding any of these headers for CRUD operations.

This also refers to this closed [PR](https://github.com/jsforce/jsforce/pull/668)