### PR TITLE
Fix recursive error bug

### DIFF
--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -113,12 +113,13 @@ inherits(Parsable, RecordStream);
 Parsable.prototype.stream = function(type, options) {
   type = type || 'csv';
   var converter = DataStreamConverters[type];
+  var self = this;
   if (!converter) {
     throw new Error('Converting [' + type + '] data stream is not supported.');
   }
   if (!this._dataStream) {
     this._dataStream = new PassThrough();
-    this._parserStream = converter.parse(options).on('error', function(error) { this.emit('error', error); });
+    this._parserStream = converter.parse(options).on('error', function(error) { self.emit('error', error); });
     this._parserStream.pipe(this).pipe(new PassThrough({ objectMode: true, highWaterMark: ( 500 * 1000 ) }));
   }
   return this._dataStream;


### PR DESCRIPTION
When emitting an error due to a bad CSV parsing, the event would recur itself which will ultimately cause a `RangeError: Maximum call stack size exceeded` error. This fix that issue.

Original PR was https://github.com/jsforce/jsforce/pull/775. It was working fine at the time because of the arrow function.