### PR TITLE
resolve issue #813 - bug in upsert of Collections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -999,7 +999,7 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
         // be aware that `allOrNone` option in upsert method will not revert the other successful requests
         // it only raises error when met at least one failed request.
         if (!isArray || options.allOrNone || !err.errorCode) { throw err; }
-        return this._toRecordResult(null, err);
+        return self._toRecordResult(null, err);
       })
     })
   ).then(function(results) {


### PR DESCRIPTION
Resolves issue #813

Issue subject: REST API - upsert on collections with { allOrNone: false } does not return array of errors