### PR TITLE
Streaming API options

### DIFF
--- a/lib/api/streaming.js
+++ b/lib/api/streaming.js
@@ -114,7 +114,7 @@ var Streaming = function(conn) {
 inherits(Streaming, events.EventEmitter);
 
 /** @private **/
-Streaming.prototype._createClient = function(forChannelName, extensions) {
+Streaming.prototype._createClient = function(forChannelName, extensions, options) {
   // forChannelName is advisory, for an API workaround. It does not restrict or select the channel.
   var needsReplayFix = typeof forChannelName === 'string' && forChannelName.indexOf('/u/') === 0;
   var endpointUrl = [
@@ -124,7 +124,7 @@ Streaming.prototype._createClient = function(forChannelName, extensions) {
     "cometd" + (needsReplayFix === true && this._conn.version === "36.0" ? "/replay" : ""),
     this._conn.version
   ].join('/');
-  var fayeClient = new Faye.Client(endpointUrl, {});
+  var fayeClient = new Faye.Client(endpointUrl, options || {});
   fayeClient.setHeader('Authorization', 'OAuth '+this._conn.accessToken);
   if (extensions instanceof Array) {
     extensions.forEach(function(extension) {
@@ -246,12 +246,28 @@ Streaming.prototype.unsubscribe = function(name, listener) {
  * 
  * subscription.cancel();
  * ```
+ *
+ * Example with options:
+ *
+ * ```javascript
+ * // Establish a Salesforce connection. (Details elided)
+ * const conn = new jsforce.Connection({ … });
+ *
+ * const fayeClient = conn.streaming.createClient([], { retry: 5 });
+ *
+ * const subscription = fayeClient.subscribe(channel, data => {
+ *   console.log('topic received data', data);
+ * });
+ *
+ * subscription.cancel();
+ * ```
  * 
  * @param {Array} Extensions - Optional, extensions to apply to the Faye client
+ * @param {Object} Extensions - Optional, options (in hash) to apply to the Faye client
  * @returns {FayeClient} - Faye client object
  */
-Streaming.prototype.createClient = function(extensions) {
-  return this._createClient(null, extensions);
+Streaming.prototype.createClient = function(extensions, options) {
+  return this._createClient(null, extensions, options);
 };
 
 /*--------------------------------------------*/


### PR DESCRIPTION
### Support for [Faye options](https://faye.jcoglan.com/browser.html) 
Allows the developer to pass an options hash to the Faye client using the `createClient` method. Example usage:
```
 const conn = new jsforce.Connection({ … });
 
 const fayeClient = conn.streaming.createClient([], { retry: 5 });
 
 const subscription = fayeClient.subscribe(channel, data => {
   console.log('topic received data', data);
 });
 
 subscription.cancel();
```