### PR TITLE
fix(http-api): adds warning when respose parsing fails

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -150,6 +150,7 @@ HttpApi.prototype.parseResponseBody = function(response) {
   try {
     return parseBody(response.body);
   } catch(e) {
+    console.error('WARN: parsing response  body crashed. Returning raw response body instead.', e);
     return response.body;
   }
 };


### PR DESCRIPTION
This would help people notice when there's an issue with the transmission.
My specific case where issues were noticed: While iterating a large data set with query/queryMore, every now and then (1 out of 500 responses) arrived only partially, as in the JSON document was cut off somewhere in the middle and was therefore in an invalid format.
The latter made the JSON.parse(..) call fail in JSForce which the library suppressed, essentially just returning a string instead of an expected Javascript object. The downstream code of mine then produced odd errors because of that. 
Having this error logging in place would've helped to debug it a lot faster (half an hour instead of a few days).

Not a hundred percent sure of the root cause yet but I did found these issues in the request library that may point to the same problem as the one I have:
https://github.com/request/request/issues/2671
https://github.com/request/request/issues/1770
https://github.com/request/request/issues/1418