### PR TITLE
Fixes NPE from unchecked access to window.location

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -26,7 +26,7 @@ if (request.defaults) {
 }
 
 var baseUrl;
-if (typeof window === 'undefined') {
+if (typeof window === 'undefined' || typeof window.location === 'undefined' ) {
   baseUrl = process.env.LOCATION_BASE_URL || "";
 } else {
   var apiHost = normalizeApiHost(window.location.host);


### PR DESCRIPTION
fixes
>TypeError: Cannot read property 'host' of undefined`.

if somehow `window` gets created on the global scope.

For example:  See https://github.com/cometd/cometd-nodejs-client/issues/17