### PR TITLE
Fix: Issue 667

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1007,7 +1007,7 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
       delete record.type;
       delete record.attributes;
 
-      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, extId].join('/');
+      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, extId ].join('/');
       return self.request({
         method : 'PATCH',
         url : url,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1001,13 +1001,13 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
   return Promise.all(
     _.map(records, function(record) {
       var sobjectType = type || (record.attributes && record.attributes.type) || record.type;
-      var extId = record[extIdField];
+      var extId = record[extIdField] || "";
       record = _.clone(record);
       delete record[extIdField];
       delete record.type;
       delete record.attributes;
 
-      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, extId ].join('/');
+      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, extId].join('/');
       return self.request({
         method : 'PATCH',
         url : url,


### PR DESCRIPTION
The upsert test suites are not passing - but I wasn't able to get them to pass originally. 

If `extIdField` is not specified in the record it sets `extId` to null, which is then ignored by the join function later on. 

To future proof may consider URI encoding the values.