### PR TITLE
Fix hardcoded http method chatter api

### DIFF
--- a/lib/api/chatter.js
+++ b/lib/api/chatter.js
@@ -270,13 +270,13 @@ Resource.prototype.retrieve = function(callback) {
  * Update specified resource
  *
  * @method Chatter~Resource#update
- * @param {Obejct} data - Data to update
+ * @param {Object} data - Data to update
  * @param {Callback.<Chatter~RequestResult>} [callback] - Callback function
  * @returns {Chatter~Request}
  */
 Resource.prototype.update = function(data, callback) {
   return this._chatter.request({
-    method: 'POST',
+    method: 'PATCH',
     url: this._url,
     body: data
   }).thenCall(callback);

--- a/test/chatter.test.js
+++ b/test/chatter.test.js
@@ -208,6 +208,19 @@ describe("chatter", function() {
       }.check(done));
     });
 
+    it("should update a comment post", function(done) {
+      conn.chatter.resource(feedElementUrl).update({
+        body: {
+          messageSegments: [{
+            type: 'Text',
+            text: 'This is an updated comment #1'
+          }]
+        }
+      }, function(err, result) {
+        if (err) { throw err; }
+      }.check(done));
+    });
+
     after(function(done) {
       conn.chatter.resource(feedElementUrl).delete(function(err, result) {
         if (err) { throw err; }


### PR DESCRIPTION
Changes:

- Fix typo on update param type annotation on chatter API
- Replace POST method by PATCH for update function on chatter API
- Add missing small test for update function

Issue reference: https://github.com/jsforce/jsforce/issues/944