### PR TITLE
Allow non JSON content type in Apex REST

### DIFF
--- a/lib/api/apex.js
+++ b/lib/api/apex.js
@@ -41,7 +41,12 @@ Apex.prototype._createRequestParams = function(method, path, body, options) {
   }
   params.headers = _headers;
   if (body) {
-    params.body = JSON.stringify(body);
+    var contentType = params.headers["Content-Type"];
+    if (!contentType || contentType === "application/json") {
+      params.body = JSON.stringify(body);
+    } else {
+      params.body = body;
+    }
   }
   return params;
 };


### PR DESCRIPTION
Fixes issue #946 by not automatically serializing Apex REST request body into JSON.
Body will be serialized in JSON if either:
- no content type is set
- content type is `application/json`