### PR TITLE
Added create method to Analytics API

### DIFF
--- a/lib/api/analytics.js
+++ b/lib/api/analytics.js
@@ -62,6 +62,26 @@ Report.prototype.describe = function(callback) {
 };
 
 /**
+ * Create new report
+ *
+ * @method Analytics~Report#create
+ * @param {Object} [report] - Report metadata
+ * @param {Callback.<Analytics~ReportMetadata>} [callback] - Callback function
+ * @returns {Promise.<Analytics~ReportMetadata>}
+ */
+Report.prototype.create = function(report, callback) {
+  var url = [ this._conn._baseUrl(), "analytics", "reports"].join('/');
+  return this._conn
+    .request({
+      method: 'POST',
+      url: url,
+      body: JSON.stringify(report),
+      headers: _.defaults({},{'Content-Type': 'application/json'})
+    })
+    .thenCall(callback);
+};
+
+/**
  * Synonym of Analytics~Report#destroy()
  *
  * @method Analytics~Report#delete


### PR DESCRIPTION
I've been working on a project to automate migration of reports from an existing org to a new org. In the process I stumbled into a report create method in the Analytics API . This patch adds a create method.