### PR TITLE
fix: buffer compatibility with node 10

### DIFF
--- a/build/jsforce-api-metadata.js
+++ b/build/jsforce-api-metadata.js
@@ -773,7 +773,7 @@ RetrieveResultLocator.prototype.stream = function() {
       if (err) {
         resultStream.emit('error', err);
       } else {
-        resultStream.push(new Buffer(result.zipFile, 'base64'));
+        resultStream.push(Buffer.from(result.zipFile, 'base64'));
         resultStream.push(null);
       }
     });
@@ -2575,7 +2575,7 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
   } else {
     var bytes = Buffer.isBuffer(val)
       ? val
-      : new Buffer(val, encoding)
+      : Buffer.from(val, encoding)
     var len = bytes.length
     if (len === 0) {
       throw new TypeError('The value "' + val +

--- a/build/jsforce-core.js
+++ b/build/jsforce-core.js
@@ -8242,7 +8242,7 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
   } else {
     var bytes = Buffer.isBuffer(val)
       ? val
-      : new Buffer(val, encoding)
+      : Buffer.from(val, encoding)
     var len = bytes.length
     if (len === 0) {
       throw new TypeError('The value "' + val +

--- a/build/jsforce.js
+++ b/build/jsforce.js
@@ -2568,7 +2568,7 @@ RetrieveResultLocator.prototype.stream = function() {
       if (err) {
         resultStream.emit('error', err);
       } else {
-        resultStream.push(new Buffer(result.zipFile, 'base64'));
+        resultStream.push(Buffer.from(result.zipFile, 'base64'));
         resultStream.push(null);
       }
     });
@@ -12041,7 +12041,7 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
   } else {
     var bytes = Buffer.isBuffer(val)
       ? val
-      : new Buffer(val, encoding)
+      : Buffer.from(val, encoding)
     var len = bytes.length
     if (len === 0) {
       throw new TypeError('The value "' + val +

--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -771,7 +771,7 @@ RetrieveResultLocator.prototype.stream = function() {
       if (err) {
         resultStream.emit('error', err);
       } else {
-        resultStream.push(new Buffer(result.zipFile, 'base64'));
+        resultStream.push(Buffer.from(result.zipFile, 'base64'));
         resultStream.push(null);
       }
     });


### PR DESCRIPTION
Still `new Buffer()` deprecated error.

[Buffer](https://nodejs.org/api/buffer.html#buffer_new_buffer_array)

> Stability: 0 - Deprecated: Use Buffer.from(array) instead.