### PR TITLE
Unify connection interface loaded from 'jsforce' and 'jsforce/core'

### DIFF
--- a/api/apex/package.json
+++ b/api/apex/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../../lib.es6/api/apex",
+  "module": "../../module/api/apex",
+  "types": "../../lib.es6/api/apex"
+}

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-const jsforce = require('./lib.es6');
-module.exports = jsforce;
+module.exports = require('./lib.es6').default;

--- a/src/api/apex.ts
+++ b/src/api/apex.ts
@@ -2,7 +2,7 @@
  * @file Manages Salesforce Apex REST endpoint calls
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import jsforce from '../core';
+import jsforce from '../jsforce';
 import Connection from '../connection';
 import { HttpRequest, HttpMethods, Schema } from '../types';
 
@@ -102,5 +102,11 @@ export default class Apex<S extends Schema> {
  * Register hook in connection instantiation for dynamically adding this API module features
  */
 jsforce.on('connection:new', (conn) => {
-  conn.apex = new Apex(conn); // eslint-disable-line no-param-reassign
+  Object.defineProperty(conn, 'apex', {
+    get() {
+      return new Apex(conn);
+    },
+    enumerable: true,
+    configurable: true,
+  });
 });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -47,6 +47,7 @@ import { QueryOptions } from './query';
 import SObject from './sobject';
 import QuickAction from './quick-action';
 import { formatDate } from './util/formatter';
+import Apex from './api/apex';
 
 /**
  * type definitions
@@ -247,6 +248,10 @@ export default class Connection<
   // describeGlobal: () => Promise<DescribeGlobalResult>;
   describeGlobal$: CachedFunction<() => Promise<DescribeGlobalResult>>;
   describeGlobal$$: CachedFunction<() => DescribeGlobalResult>;
+
+  // API libs are not instantiated here so that core module to remain without dependencies to them
+  // It is responsible for develpers to import api libs explicitly if they are using 'jsforce/core' instead of 'jsforce'.
+  apex: Apex<S> = (undefined as any) as Apex<S>;
 
   /**
    *

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -251,7 +251,11 @@ export default class Connection<
 
   // API libs are not instantiated here so that core module to remain without dependencies to them
   // It is responsible for develpers to import api libs explicitly if they are using 'jsforce/core' instead of 'jsforce'.
-  apex: Apex<S> = (undefined as any) as Apex<S>;
+  get apex(): Apex<S> {
+    throw new Error(
+      "API module 'apex' is not loaded, load 'jsforce/api/apex' explicitly",
+    );
+  }
 
   /**
    *

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2,6 +2,7 @@
  *
  */
 import EventEmitter from 'events';
+import jsforce from './jsforce';
 import {
   HttpRequest,
   HttpResponse,
@@ -348,6 +349,8 @@ export default class Connection<
       serverUrl,
       signedRequest,
     });
+
+    jsforce.emit('connection:new', this);
   }
 
   /* @private */

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,25 +1,18 @@
-/**
- * @file JSforce Core
- * @author Shinichi Tomita <shinichi.tomita@gmail.com>
- */
-import EventEmitter from 'events';
 import VERSION from './VERSION';
 import Connection from './connection';
 import OAuth2 from './oauth2';
 import SfDate from './date';
 import registry, { Registry } from './registry';
-
-class JSforce extends EventEmitter {
-  VERSION: typeof VERSION = VERSION;
-  Connection: typeof Connection = Connection;
-  OAuth2: typeof OAuth2 = OAuth2;
-  SfDate: typeof SfDate = SfDate;
-  Date: typeof SfDate = SfDate;
-  registry: Registry = registry;
-}
-
-const jsforce = new JSforce();
+import jsforce from './jsforce';
 
 export * from './types';
-export { VERSION, Connection, OAuth2, SfDate as Date, SfDate };
+export {
+  VERSION,
+  Connection,
+  OAuth2,
+  SfDate as Date,
+  SfDate,
+  Registry,
+  registry,
+};
 export default jsforce;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,24 @@
+import Apex from './api/apex';
 export * from './types';
-export * from './jsforce';
 import jsforce from './jsforce';
+
+import {
+  VERSION,
+  Connection as ConnectionCore,
+  OAuth2,
+  Date,
+  SfDate,
+  Registry,
+  registry,
+} from './core';
+import { Schema } from './types';
+
+export { VERSION, OAuth2, Date, SfDate, Registry, registry };
+
+export class Connection<S extends Schema = Schema> extends ConnectionCore<S> {
+  apex: Apex<S> = new Apex<S>(this);
+}
+
+jsforce.Connection = Connection;
+
 export default jsforce;

--- a/src/jsforce.ts
+++ b/src/jsforce.ts
@@ -2,8 +2,13 @@
  *
  */
 import Apex from './api/apex';
-import ConnectionCore from './connection';
-import jsforce, { OAuth2, Date, SfDate, VERSION } from './core';
+import jsforce, {
+  Connection as ConnectionCore,
+  OAuth2,
+  Date,
+  SfDate,
+  VERSION,
+} from './core';
 import { Schema } from './types';
 
 export { OAuth2, Date, SfDate, VERSION };

--- a/src/jsforce.ts
+++ b/src/jsforce.ts
@@ -1,22 +1,21 @@
+import EventEmitter from 'events';
+import VERSION from './VERSION';
+import Connection from './connection';
+import OAuth2 from './oauth2';
+import SfDate from './date';
+import registry, { Registry } from './registry';
+
 /**
  *
  */
-import Apex from './api/apex';
-import jsforce, {
-  Connection as ConnectionCore,
-  OAuth2,
-  Date,
-  SfDate,
-  VERSION,
-} from './core';
-import { Schema } from './types';
-
-export { OAuth2, Date, SfDate, VERSION };
-
-export class Connection<S extends Schema = Schema> extends ConnectionCore<S> {
-  apex: Apex<S> = new Apex(this);
+class JSforce extends EventEmitter {
+  VERSION: typeof VERSION = VERSION;
+  Connection: typeof Connection = Connection;
+  OAuth2: typeof OAuth2 = OAuth2;
+  SfDate: typeof SfDate = SfDate;
+  Date: typeof SfDate = SfDate;
+  registry: Registry = registry;
 }
 
-jsforce.Connection = Connection;
-
+const jsforce = new JSforce();
 export default jsforce;

--- a/src/registry/base.ts
+++ b/src/registry/base.ts
@@ -6,7 +6,7 @@ import {
   ClientConfig,
 } from './types';
 import jsforce from '../core';
-import { Connection, Schema } from '..';
+import { Schema } from '..';
 
 /**
  *

--- a/src/registry/base.ts
+++ b/src/registry/base.ts
@@ -35,7 +35,7 @@ export class BaseRegistry implements Registry {
 
   async getConnection<S extends Schema = Schema>(name: string) {
     const config = await this.getConnectionConfig(name);
-    return config ? (new jsforce.Connection<S>(config) as Connection<S>) : null;
+    return config ? new jsforce.Connection<S>(config) : null;
   }
 
   async getConnectionConfig(name?: string) {

--- a/src/registry/sfdx.ts
+++ b/src/registry/sfdx.ts
@@ -105,8 +105,8 @@ export class SfdxRegistry implements Registry {
   }
 
   async getConnection<S extends Schema = Schema>(name?: string) {
-    const connConfig = await this.getConnectionConfig(name);
-    return new jsforce.Connection<S>(connConfig) as Connection<S>;
+    const config = await this.getConnectionConfig(name);
+    return config ? new jsforce.Connection<S>(config) : null;
   }
 
   async _getOrgInfo(username?: string) {
@@ -145,7 +145,7 @@ export class SfdxRegistry implements Registry {
   async getConnectionConfig(name?: string) {
     const orgInfo = await this._getOrgInfo(name);
     if (!orgInfo) {
-      return;
+      return null;
     }
     const { accessToken, instanceUrl, loginUrl } = orgInfo;
     return { accessToken, instanceUrl, loginUrl };

--- a/src/registry/sfdx.ts
+++ b/src/registry/sfdx.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import { Registry, ConnectionConfig, ClientConfig } from './types';
 import jsforce from '../core';
-import { Connection, Schema } from '..';
+import { Schema } from '..';
 
 type SfdxCommandOutput = {
   status: number;

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -2,7 +2,7 @@
  * @file Registry for connection information, cached in local file system
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import { Connection } from '../jsforce';
+import { Connection } from '..';
 import { Schema } from '../types';
 
 export type ConnectionConfig = {
@@ -39,17 +39,15 @@ export interface Registry {
   getConnectionNames(): Promise<string[]>;
   getConnection<S extends Schema = Schema>(
     name?: string,
-  ): Promise<Connection<S> | null | undefined>;
-  getConnectionConfig(
-    name?: string,
-  ): Promise<ConnectionConfig | null | undefined>;
+  ): Promise<Connection<S> | null>;
+  getConnectionConfig(name?: string): Promise<ConnectionConfig | null>;
   saveConnectionConfig(
     name: string,
     connConfig: ConnectionConfig,
   ): Promise<void>;
   setDefaultConnection(name: string): Promise<void>;
   removeConnectionConfig(name: string): Promise<void>;
-  getClientConfig(name: string): Promise<ClientConfig | null | undefined>;
+  getClientConfig(name: string): Promise<ClientConfig | null>;
   getClientNames(): Promise<string[]>;
   registerClientConfig(name: string, clientConfig: ClientConfig): Promise<void>;
 }


### PR DESCRIPTION
Currently `Connection` class imported from 'jsforce' has api lib modules reference in its properties, on the other hand that from 'jsforce/core' doesn't. It is to remove unnecessary reference to reduce the bundled code size. Unify the interface to have the api module properties, but actual access in connection from 'jsforce/core' to become error.