### PR TITLE
Use es5 built file for csv-parse/stringify usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsforce",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "database.com"
   ],
   "homepage": "http://github.com/jsforce/jsforce",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "repository": {
     "type": "git",
     "url": "git://github.com/jsforce/jsforce.git"

--- a/src/VERSION.ts
+++ b/src/VERSION.ts
@@ -1,1 +1,1 @@
-export default '2.0.0-alpha.7';
+export default '2.0.0-alpha.8';

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -2,10 +2,10 @@
  *
  */
 import { Transform } from 'stream';
-import csvParse, { Options as ParseOpts } from 'csv-parse';
-import csvParseSync from 'csv-parse/lib/sync';
-import csvStringify, { Options as StringifyOpts } from 'csv-stringify';
-import csvStringifySync from 'csv-stringify/lib/sync';
+import csvParse, { Options as ParseOpts } from 'csv-parse/lib/es5';
+import csvParseSync from 'csv-parse/lib/es5/sync';
+import csvStringify, { Options as StringifyOpts } from 'csv-stringify/lib/es5';
+import csvStringifySync from 'csv-stringify/lib/es5/sync';
 
 /**
  * @private


### PR DESCRIPTION
As the csv-parse/stringify includes non-es5 syntax, it fails when bundled and run in classic web browser like IE11.