### PR TITLE
Add support for custom headers in Chatter request #883

### DIFF
--- a/lib/api/chatter.js
+++ b/lib/api/chatter.js
@@ -27,9 +27,10 @@ var Chatter = module.exports = function(conn) {
 Chatter.prototype._request = function(params, callback) {
   if (/^(put|post|patch)$/i.test(params.method)) {
     if (_.isObject(params.body)) {
-      params.headers = {
-        "Content-Type": "application/json"
-      };
+      params.headers = _.defaults(
+        { "Content-Type": "application/json" },
+        (_.isObject(params.headers) ? params.headers : {})
+      );
       params.body = JSON.stringify(params.body);
     }
   }
@@ -80,10 +81,11 @@ Chatter.prototype.request = function(params, callback) {
  *
  * @param {String} url - Resource URL
  * @param {Object} [queryParams] - Query parameters (in hash object)
+ * @param {Object} [headers] - Request headers (in hash object)
  * @returns {Chatter~Resource}
  */
-Chatter.prototype.resource = function(url, queryParams) {
-  return new Resource(this, url, queryParams);
+Chatter.prototype.resource = function(url, queryParams, headers) {
+  return new Resource(this, url, queryParams, headers);
 };
 
 /**
@@ -225,15 +227,16 @@ Request.prototype.thenCall = function(callback) {
  * @param {Chatter} chatter - Chatter API object
  * @param {String} url - Resource URL
  * @param {Object} [queryParams] - Query parameters (in hash object)
+ * @param {Object} [headers] - Request headers (in hash object)
  */
-var Resource = function(chatter, url, queryParams) {
+var Resource = function(chatter, url, queryParams, headers) {
   if (queryParams) {
     var qstring = _.map(_.keys(queryParams), function(name) {
       return name + "=" + encodeURIComponent(queryParams[name]);
     }).join('&');
     url += (url.indexOf('?') > 0 ? '&' : '?') + qstring;
   }
-  Resource.super_.call(this, chatter, { method: 'GET', url: url });
+  Resource.super_.call(this, chatter, { method: 'GET', url: url, headers: headers });
   this._url = url;
 };
 


### PR DESCRIPTION
Added support for adding custom headers in Chatter requests to send headers like `{ 'X-Connect-Theme': 'Salesforce1' }` to retrieve themed default icons.

Referenced issue: #883 