### PR TITLE
Update connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,7 +23,7 @@ var events  = require('events'),
 var defaults = {
   loginUrl: "https://login.salesforce.com",
   instanceUrl: "",
-  version: "42.0"
+  version: "48.0"
 };
 
 /*


### PR DESCRIPTION
Change default API version to latest GA version currently (Spring 20). It's not obvious when using the library that the default API version is from Spring 18 (v42.0) limiting your from using some of the newer capabilities.