### PR TITLE
Update lodash to 4.17.19 to fix Object Prototype Pollution Security Vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsforce",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2284,12 +2284,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.6.3.tgz",
-      "integrity": "sha512-pAxEb5kabSaKEwqSXv7vpq6eucXQgY67MLpeLwnYCd21YjTD5OCIIIXGKyUKN/uNQNnzW/elNfxJfozQ1EjB/g==",
-      "requires": {
-        "pad": "^3.2.0"
-      }
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.10.1.tgz",
+      "integrity": "sha512-gdDJVchi0oSLIcYXz1H/VSgLE6htHDqJyFsRU/vTkQgmVOZ3S0IR2LXnNbWUYG7VD76dYVwdfBLyx8AX9+An8A=="
     },
     "csv-stringify": {
       "version": "1.1.2",
@@ -2408,21 +2405,6 @@
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
       "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
       "dev": true
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "^1.0.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.2",
@@ -5506,9 +5488,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -6454,14 +6436,6 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
-    },
-    "pad": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
-      "integrity": "sha512-2u0TrjcGbOjBTJpyewEl4hBO3OeX5wWue7eIFPzQTg6wFSvoaHcBTTUY5m+n0hd04gmTCPuY0kCpVIVuw5etwg==",
-      "requires": {
-        "wcwidth": "^1.0.1"
-      }
     },
     "pako": {
       "version": "1.0.6",
@@ -8802,14 +8776,6 @@
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
       "dev": true
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "csv-stringify": "^1.0.4",
     "faye": "^1.2.0",
     "inherits": "^2.0.1",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.19",
     "multistream": "^2.0.5",
     "opn": "^5.3.0",
     "promise": "^7.1.1",


### PR DESCRIPTION
Update lodash to 4.17.19 to fix Object Prototype Pollution Security Vulnerability:
* Snyk lodash vulnerability report https://snyk.io/vuln/SNYK-JS-LODASH-567746
* Merged/released lodash PR: https://github.com/lodash/lodash/pull/4759
