### PR TITLE
Address Security Vulnerabilities in Faye + Upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsforce",
-  "version": "1.9.2",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2254,7 +2254,7 @@
     },
     "csprng": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/csprng/-/csprng-0.1.2.tgz",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/csprng/-/csprng-0.1.2.tgz",
       "integrity": "sha1-S8aPEvo2jSUqWYQcusqXSxirReI=",
       "requires": {
         "sequin": "*"
@@ -2284,12 +2284,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.6.3.tgz",
-      "integrity": "sha512-pAxEb5kabSaKEwqSXv7vpq6eucXQgY67MLpeLwnYCd21YjTD5OCIIIXGKyUKN/uNQNnzW/elNfxJfozQ1EjB/g==",
-      "requires": {
-        "pad": "^3.2.0"
-      }
+      "version": "4.11.1",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/csv-parse/-/csv-parse-4.11.1.tgz",
+      "integrity": "sha1-OTWnhi1+QxAgolU4kF3sAVP6db0="
     },
     "csv-stringify": {
       "version": "1.1.2",
@@ -2408,21 +2405,6 @@
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
       "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
       "dev": true
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "^1.0.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.2",
@@ -3401,21 +3383,22 @@
       "dev": true
     },
     "faye": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.2.4.tgz",
-      "integrity": "sha1-l47YpY8dSB5cH5i6y4lZ3l7FxkM=",
+      "version": "1.3.0",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/faye/-/faye-1.3.0.tgz",
+      "integrity": "sha1-qBOa2cRe701fqqUqI9K5LDjXJUs=",
       "requires": {
         "asap": "*",
         "csprng": "*",
         "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
         "tough-cookie": "*",
         "tunnel-agent": "*"
       }
     },
     "faye-websocket": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "version": "0.11.3",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -4793,9 +4776,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
+      "version": "0.5.2",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/http-parser-js/-/http-parser-js-0.5.2.tgz",
+      "integrity": "sha1-2i4x0jezk6rnKs5DiC3X4nCo/3c="
     },
     "http-proxy": {
       "version": "1.17.0",
@@ -6455,14 +6438,6 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
-    "pad": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
-      "integrity": "sha512-2u0TrjcGbOjBTJpyewEl4hBO3OeX5wWue7eIFPzQTg6wFSvoaHcBTTUY5m+n0hd04gmTCPuY0kCpVIVuw5etwg==",
-      "requires": {
-        "wcwidth": "^1.0.1"
-      }
-    },
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -6861,9 +6836,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
+      "version": "1.8.0",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
     },
     "public-encrypt": {
       "version": "4.0.2",
@@ -7475,7 +7450,7 @@
     },
     "sequin": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sequin/-/sequin-0.1.1.tgz",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/sequin/-/sequin-0.1.1.tgz",
       "integrity": "sha1-XC04nWajg3NOqvvEXt6ywcsb5wE="
     },
     "serve-static": {
@@ -8290,12 +8265,20 @@
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "4.0.0",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        }
       }
     },
     "traverse": {
@@ -8544,6 +8527,11 @@
           "dev": true
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -8803,27 +8791,20 @@
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
       "dev": true
     },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
-    },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.4",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha1-ia1Slbv2S0gKvLox5JU6ynBvV2A=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://artifactory.wwt.com/artifactory/api/npm/npm/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "database.com"
   ],
   "homepage": "http://github.com/jsforce/jsforce",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/jsforce/jsforce.git"
@@ -62,7 +62,7 @@
     "commander": "^2.9.0",
     "csv-parse": "^4.10.1",
     "csv-stringify": "^1.0.4",
-    "faye": "^1.2.0",
+    "faye": "^1.3.0",
     "inherits": "^2.0.1",
     "lodash": "^4.17.14",
     "multistream": "^2.0.5",


### PR DESCRIPTION
Affected Faye versions include 1.2.0-1.2.4
Resolved in version 1.2.5+
Upgrades to version 1.3.0

Details of Vulnerability: GHSA-qpg4-4w7w-2mq5

Addresses Issue #1009