### PR TITLE
Add support to JWT Bearer flow authentication

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1262,6 +1262,31 @@ Connection.prototype.authorize = function(code, params, callback) {
 
 };
 
+/**
+ * Authorize (using oauth2 server to server flow)
+ *
+ * @param {Callback.<UserInfo>} [callback] - Callback function
+ * @returns {Promise.<UserInfo>}
+ */
+Connection.prototype.authorizeByToken = function(callback) {
+  var self = this;
+  var logger = this._logger;
+
+  return this.oauth2.authenticateWithJWT().then(function(res) {
+    var userInfo = parseIdUrl(res.id);
+    self.initialize({
+      instanceUrl : res.instance_url,
+      accessToken : res.access_token,
+      refreshToken : res.refresh_token,
+      userInfo: userInfo
+    });
+    logger.debug("<login> completed. user id = " + userInfo.id + ", org id = " + userInfo.organizationId);
+    return userInfo;
+
+  }).thenCall(callback);
+
+};
+
 
 /**
  * Login to Salesforce

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,6 +10,7 @@ var jsforce = module.exports = new EventEmitter();
 jsforce.VERSION = require('./VERSION');
 jsforce.Connection = require('./connection');
 jsforce.OAuth2 = require('./oauth2');
+jsforce.JWT = require('./jwt');
 jsforce.Date = jsforce.SfDate = require("./date");
 jsforce.RecordStream = require('./record-stream');
 jsforce.Promise = require('./promise');

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -1,0 +1,56 @@
+/**
+ * @file Manages Salesforce OAuth2 JWT flow specific operations
+ * @author Rafael Galani <galani.rafael@gmail.com>
+ */
+
+'use strict';
+
+var jwt = require('jsonwebtoken'),
+    _ = require('lodash/core');
+
+var defaults = {
+  loginUrl : "https://login.salesforce.com"
+};
+
+/**
+ * JWT class
+ *
+ * @class
+ * @constructor
+ * @param {Object} options -  config options
+ * @param {String} options.clientId - OAuth2 client ID.
+ * @param {String} options.username - Salesforce username - Username must be preauthorized when using the JWT flow.
+ * @param {String} options.privateKey - X509 key, base64 encoded - Salesforce uploaded certificate (signing secret) must match this key.
+ * @param {String} [options.loginUrl] - Salesforce login server URL.
+ */
+var JWT = module.exports = function(options) {
+  this.loginUrl = options.loginUrl || defaults.loginUrl;
+  this.clientId = options.clientId;
+  this.privateKey = options.privateKey;
+  this.username = options.username;
+};
+
+/**
+ *
+ */
+_.extend(JWT.prototype, /** @lends JWT.prototype **/ {
+
+  /**
+   * Get JWT representation as token.
+   *
+   * @returns {String} JWT String
+   */
+  getToken : function() {
+    const privateKey = new Buffer.from(this.privateKey, 'base64').toString('ascii');
+    
+    const claims = {
+      iss: this.clientId, 
+      sub: this.username, 
+      aud: this.loginUrl, 
+      exp: Math.floor(Date.now()/1000) + (3*60)
+    };
+    const token = jwt.sign(claims, privateKey, { algorithm: 'RS256'});
+    return token;
+  },
+
+});

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -7,6 +7,7 @@
 
 var querystring = require('querystring'),
     _ = require('lodash/core'),
+    JWT = require('./jwt'),
     Transport = require('./transport');
 
 var defaults = {
@@ -24,6 +25,7 @@ var defaults = {
  * @param {String} [options.tokenServiceUrl] - OAuth2 token service URL. If not specified it generates from default by adding to login server URL.
  * @param {String} options.clientId - OAuth2 client ID.
  * @param {String} [options.clientSecret] - OAuth2 client secret (This is optional for public client).
+ * @param {JWT}    [options.jwt] - JWT instance in order to authenticate in a server to server flow.
  * @param {String} options.redirectUri - URI to be callbacked from Salesforce OAuth2 authorization service.
  */
 var OAuth2 = module.exports = function(options) {
@@ -32,13 +34,18 @@ var OAuth2 = module.exports = function(options) {
     this.authzServiceUrl = options.authzServiceUrl;
     this.tokenServiceUrl = options.tokenServiceUrl;
     this.revokeServiceUrl = options.revokeServiceUrl;
+  } else if (options.jwt){
+    this.jwt = new JWT(options.jwt);
+    this.loginUrl = this.jwt.loginUrl;
+    this.clientId = this.jwt.clientId;
+    this.tokenServiceUrl = this.loginUrl + "/services/oauth2/token";
   } else {
     this.loginUrl = options.loginUrl || defaults.loginUrl;
     this.authzServiceUrl = this.loginUrl + "/services/oauth2/authorize";
     this.tokenServiceUrl = this.loginUrl + "/services/oauth2/token";
     this.revokeServiceUrl = this.loginUrl + "/services/oauth2/revoke";
   }
-  this.clientId = options.clientId;
+  this.clientId = this.clientId || options.clientId;
   this.clientSecret = options.clientSecret;
   this.redirectUri = options.redirectUri;
   if (options.proxyUrl) {
@@ -139,13 +146,30 @@ _.extend(OAuth2.prototype, /** @lends OAuth2.prototype **/ {
    * @returns {Promise.<TokenResponse>}
    */
   authenticate : function(username, password, callback) {
+    if (!this.jwt){
+      return this._postParams({
+        grant_type : "password",
+        username : username,
+        password : password,
+        client_id : this.clientId,
+        client_secret : this.clientSecret,
+        redirect_uri : this.redirectUri
+      }, callback);
+    } else {
+      return this.authenticateWithJWT(callback);
+    }
+  },
+
+  /**
+   * OAuth2 Server to server Flow (Resource Owner Password Credentials)
+   *
+   * @param {Callback.<TokenResponse>} [callback] - Callback function
+   * @returns {Promise.<TokenResponse>}
+   */
+  authenticateWithJWT : function(callback) {
     return this._postParams({
-      grant_type : "password",
-      username : username,
-      password : password,
-      client_id : this.clientId,
-      client_secret : this.clientSecret,
-      redirect_uri : this.redirectUri
+      grant_type : "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion : this.jwt.getToken(),
     }, callback);
   },
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "csv-stringify": "^1.0.4",
     "faye": "^1.2.0",
     "inherits": "^2.0.1",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.19",
     "multistream": "^2.0.5",
     "opn": "^5.3.0",

--- a/test/config/salesforce.js
+++ b/test/config/salesforce.js
@@ -13,4 +13,5 @@ module.exports = {
   upsertField :   "ExtId__c",
   proxyUrl :      process.env.SF_AJAX_PROXY_URL,
   logLevel :      process.env.DEBUG,
+  privateKey :    process.env.JWT_PRIVATE_KEY,
 };

--- a/test/oauth2.test.js
+++ b/test/oauth2.test.js
@@ -65,6 +65,19 @@ if (TestEnv.isNodeJS) {
     });
   });
 
+  var oauth2 = new OAuth2({
+    jwt: config
+  });
+
+  describe("OAuth2 JWT bearer flow : authenticate", function() {
+    it("should receive access token", function(done) {
+      oauth2.authenticateWithJWT(function(err, res) {
+        if (err) { throw err; }
+        assert.ok(_.isString(res.access_token));
+      }.check(done));
+    });
+  });
+
 }
 /*------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This enables the capability to authenticate using the [JWT bearer flow (server to server).](https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=5 "JWT bearer flow (server to server).")

A new `JWT` module was created, along with a few methods in order to authenticate through it.
I am not entirely sure whether this would be the final implementation, since the `oauth2` module methods are coupled to the [OAuth2 Web Server flow](https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5 "OAuth2 Web Server flow"). Since the JWT Bearer flow doesn't issue refresh tokens and uses different parameters and logic, I believe that a further revaluation of the modules responsibilities and code refactoring should be considered.

### Usage

```javascript
const jsforce = require('jsforce')

const conn = new jsforce.Connection({
    oauth2: {
        jwt: {
            privateKey: process.env.SF_JWT_PRIVATE_KEY,
            clientId:   process.env.SF_CLIENT_ID,
            username:   process.env.SF_USERNAME,
            loginUrl:   process.env.SF_LOGIN_URL,
        }
    }
});

conn.authorizeByToken(function(err, userInfo){
    if (err) { 
        console.error(err);
    }
    console.info('User information: ', userInfo);
});
```

### Observations

A X509 certificate/key pair must be generated in order to use this flow. These values are sensitive and must be stored safely.
The app must also be configured to use this certificate, by uploading the file in the "Use digital signature" field, at the ConnectedApp configuration page. More information can be found here: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_key_and_cert.htm.

## JWT
### Properties
- `clientId` - required - OAuth2 application client ID.
- `username` - required - Salesforce username - (Username must be preauthorized when using the JWT flow)
- `privateKey` - required - X509 key, base64 encoded - Salesforce uploaded certificate (signing secret) must match this key.
- `loginUrl` - optional - Salesforce login URL. `https://login.salesforce.com` is the default value.

### Methods
- `getToken()` - Get JWT representation as token.
Returns a string containing the claims signed with the provided key. Example: 

```string
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJZT1VSX0NMSUVOVF9JRCIsInN1YiI6InVzZXJuYW1lQGRvbWFpbi5jb20iLCJhdWQiOiJMT0dJTl9VUkxfX3Rlc3R8bG9naW4iLCJleHAiOjE1OTYzODk0NDYsImlhdCI6MTU5NjM4OTI2Nn0.E3k3s7rLFeejtw6bm2AliOeoaHtUp4Hdji6Hetp0EnIjqcXiD1N7XZUmYiNrkM4KSj1YtfLBQh4ziNo0o7UKPcCr3b8H0-mVPYUpH4IMna45pAAV6fbDVCCjV-2GAHYyUUlRcJONTQqvNOPS04bjW-Mt8qFSMNc3c5bGgof9Lig6WF6AgToLcCVK0X9-046PbWcYONMoYXyIwkdVDgy_8LT0HjXDLi5vJM1xYpubxwSvr1T3e0DhCCm7eDsrW0jnCVsR0zvZNqmKEDSHyZU2_QYwgOHH8k82N34ptkM9Y-K6FWdMJXWQbQH14KPYtHY0aWwbL-I97DiEdZA0Nbl3CQ
```

## Connection
### Added methods
- `authorizeByToken(callback)` - Method used to authorize the client using the provided JWT credentials. The previous method was not used since it had hard coupled parameters bound to it, and it could lead to incompatibilities in the future. Example: 

```javascript
conn.authorizeByToken(function(err, userInfo){
    if (err) { 
        console.error(err);
    }
    console.info('User information: ', userInfo);
});
```

## OAuth2
### Added methods
- `authenticateWithJWT(callback)` - Method used to authorize the client using the provided JWT credentials. Same thing for the Connection module: user and pass parameters were bound to the auth calls, so a new one was created. Example: 

```javascript
oauth2.authenticateWithJWT(function(err, userInfo){
    if (err) { 
        console.error(err);
    }
    console.info('User information: ', userInfo);
});
```