### PR TITLE
fix: update gitignore & remove test folder from getting published to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,38 @@
-lib-cov
-*.seed
-*.log
 *.dat
 *.out
-*.pid
 *.gz
 
-pids
-logs
 results
 
-node_modules
-npm-debug.log
-
 .npmignore
+
+# Dependency directories
+node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Directory for instrumented libs
+lib-cov
+
+# Eclipse configs
+.project
+
+# Webstorm configs
+.idea/
+
+# MacOS folder atttribute tracking
+**/.DS_Store
+
+# tarball generated for publishing
+*.tgz

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bin",
     "build",
     "lib",
-    "test",
     "core.js",
     "index.js"
   ],


### PR DESCRIPTION
This PR removes the `test` folder from getting published to `npm`. 
It also updates the `.gitignore` file, adding some missing files/folders that should be ignored.