### PR TITLE
Parameterize max_dml_count and max_batch_request

### DIFF
--- a/build/jsforce-core.js
+++ b/build/jsforce-core.js
@@ -780,18 +780,10 @@ var events  = require('events'),
 var defaults = {
   loginUrl: "https://login.salesforce.com",
   instanceUrl: "",
-  version: "42.0"
+  version: "42.0",
+  max_dml_count : 200,
+  max_batch_request: 25
 };
-
-/*
- * Constant of maximum records num in DML operation (update/delete)
- */
-var MAX_DML_COUNT = 200;
-
-/*
- * Constant of maximum number of requests that can be batched
- */
-var MAX_BATCH_REQUESTS = 25;
 
 /**
  * Connection class to keep the API session information and manage requests
@@ -813,6 +805,8 @@ var MAX_BATCH_REQUESTS = 25;
  * @param {String} [options.proxyUrl] - Cross-domain proxy server URL, used in browser client, non Visualforce app.
  * @param {String} [options.httpProxy] - URL of HTTP proxy server, used in server client.
  * @param {Object} [options.callOptions] - Call options used in each SOAP/REST API request. See manual.
+ * @param {Number} [options.max_dml_count] - Constant of maximum records num in DML operation (update/delete)
+ * @param {Number} [options.max_batch_request] - Constant of maximum number of requests that can be batched
  */
 var Connection = module.exports = function(options) {
   options = options || {};
@@ -837,6 +831,8 @@ var Connection = module.exports = function(options) {
   this.loginUrl = options.loginUrl || oauth2.loginUrl || defaults.loginUrl;
   this.version = options.version || defaults.version;
   this.maxRequest = options.maxRequest || this.maxRequest || 10;
+  this.max_dml_count = options.max_dml_count || defaults.max_dml_count;
+  this.max_batch_request = options.max_batch_request || defaults.max_batch_request;
 
   /** @private */
   if (options.proxyUrl) {
@@ -935,8 +931,8 @@ var Connection = module.exports = function(options) {
     key: function(options) {
       var types = options.types;
       var autofetch = options.autofetch || false;
-      var typesToFetch = types.length > MAX_BATCH_REQUESTS 
-        ? (autofetch ? types : types.slice(0, MAX_BATCH_REQUESTS))
+      var typesToFetch = types.length > this.max_batch_request 
+        ? (autofetch ? types : types.slice(0, this.max_batch_request))
         : types;
       var keys = [];
       typesToFetch.forEach(function (type) { keys.push('describe.' + type); });
@@ -1565,10 +1561,10 @@ Connection.prototype._createMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
-  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (records.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._createMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._createMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._createMany(type, records.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._createMany(type, records.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -1684,10 +1680,10 @@ Connection.prototype._updateMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
-  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (records.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._updateMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._updateMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._updateMany(type, records.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._updateMany(type, records.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -1881,10 +1877,10 @@ Connection.prototype._destroyMany = function(type, ids, options) {
   if (ids.length === 0) {
     return Promise.resolve([]);
   }
-  if (ids.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (ids.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._destroyMany(type, ids.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._destroyMany(type, ids.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._destroyMany(type, ids.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._destroyMany(type, ids.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -2012,9 +2008,9 @@ Connection.prototype.batchDescribe = Connection.prototype.batchDescribeSObjects 
   var maxConcurrentRequests = Math.min((options.maxConcurrentRequests || 15), 15);
   var batches = [];
   do {
-    var batch = types.length > MAX_BATCH_REQUESTS ? types.slice(0, MAX_BATCH_REQUESTS) : types;
+    var batch = types.length > this.max_batch_request ? types.slice(0, this.max_batch_request) : types;
     batches.push(batch);
-    types = types.length > MAX_BATCH_REQUESTS ? types.slice(MAX_BATCH_REQUESTS) : [];
+    types = types.length > this.max_batch_request ? types.slice(this.max_batch_request) : [];
   } while (types.length > 0 && autofetch);
   var requestBatches = [];
   do {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,18 +23,10 @@ var events  = require('events'),
 var defaults = {
   loginUrl: "https://login.salesforce.com",
   instanceUrl: "",
-  version: "42.0"
+  version: "42.0",
+  max_dml_count : 200,
+  max_batch_request: 25
 };
-
-/*
- * Constant of maximum records num in DML operation (update/delete)
- */
-var MAX_DML_COUNT = 200;
-
-/*
- * Constant of maximum number of requests that can be batched
- */
-var MAX_BATCH_REQUESTS = 25;
 
 /**
  * Connection class to keep the API session information and manage requests
@@ -56,6 +48,8 @@ var MAX_BATCH_REQUESTS = 25;
  * @param {String} [options.proxyUrl] - Cross-domain proxy server URL, used in browser client, non Visualforce app.
  * @param {String} [options.httpProxy] - URL of HTTP proxy server, used in server client.
  * @param {Object} [options.callOptions] - Call options used in each SOAP/REST API request. See manual.
+ * @param {Number} [options.max_dml_count] - Constant of maximum records num in DML operation (update/delete)
+ * @param {Number} [options.max_batch_request] - Constant of maximum number of requests that can be batched
  */
 var Connection = module.exports = function(options) {
   options = options || {};
@@ -80,6 +74,8 @@ var Connection = module.exports = function(options) {
   this.loginUrl = options.loginUrl || oauth2.loginUrl || defaults.loginUrl;
   this.version = options.version || defaults.version;
   this.maxRequest = options.maxRequest || this.maxRequest || 10;
+  this.max_dml_count = options.max_dml_count || defaults.max_dml_count;
+  this.max_batch_request = options.max_batch_request || defaults.max_batch_request;
 
   /** @private */
   if (options.proxyUrl) {
@@ -178,8 +174,8 @@ var Connection = module.exports = function(options) {
     key: function(options) {
       var types = options.types;
       var autofetch = options.autofetch || false;
-      var typesToFetch = types.length > MAX_BATCH_REQUESTS 
-        ? (autofetch ? types : types.slice(0, MAX_BATCH_REQUESTS))
+      var typesToFetch = types.length > this.max_batch_request 
+        ? (autofetch ? types : types.slice(0, this.max_batch_request))
         : types;
       var keys = [];
       typesToFetch.forEach(function (type) { keys.push('describe.' + type); });
@@ -808,10 +804,10 @@ Connection.prototype._createMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
-  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (records.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._createMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._createMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._createMany(type, records.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._createMany(type, records.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -927,10 +923,10 @@ Connection.prototype._updateMany = function(type, records, options) {
   if (records.length === 0) {
     return Promise.resolve([]);
   }
-  if (records.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (records.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._updateMany(type, records.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._updateMany(type, records.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._updateMany(type, records.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._updateMany(type, records.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -1124,10 +1120,10 @@ Connection.prototype._destroyMany = function(type, ids, options) {
   if (ids.length === 0) {
     return Promise.resolve([]);
   }
-  if (ids.length > MAX_DML_COUNT && options.allowRecursive) {
+  if (ids.length > this.max_dml_count && options.allowRecursive) {
     var self = this;
-    return self._destroyMany(type, ids.slice(0, MAX_DML_COUNT), options).then(function(rets1) {
-      return self._destroyMany(type, ids.slice(MAX_DML_COUNT), options).then(function(rets2) {
+    return self._destroyMany(type, ids.slice(0, this.max_dml_count), options).then(function(rets1) {
+      return self._destroyMany(type, ids.slice(this.max_dml_count), options).then(function(rets2) {
         return rets1.concat(rets2);
       });
     });
@@ -1255,9 +1251,9 @@ Connection.prototype.batchDescribe = Connection.prototype.batchDescribeSObjects 
   var maxConcurrentRequests = Math.min((options.maxConcurrentRequests || 15), 15);
   var batches = [];
   do {
-    var batch = types.length > MAX_BATCH_REQUESTS ? types.slice(0, MAX_BATCH_REQUESTS) : types;
+    var batch = types.length > this.max_batch_request ? types.slice(0, this.max_batch_request) : types;
     batches.push(batch);
-    types = types.length > MAX_BATCH_REQUESTS ? types.slice(MAX_BATCH_REQUESTS) : [];
+    types = types.length > this.max_batch_request ? types.slice(this.max_batch_request) : [];
   } while (types.length > 0 && autofetch);
   var requestBatches = [];
   do {


### PR DESCRIPTION
Allows for customized parameterization for dml_count for updates and deletes and batch_requests.

Might make sense to put this into config at some point.