### PR TITLE
Fix eventemitter

### DIFF
--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -2,7 +2,7 @@
  * @file Manages Salesforce Bulk API related operations
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
 import joinStreams from 'multistream';
 import Connection from '../connection';

--- a/src/api/streaming.ts
+++ b/src/api/streaming.ts
@@ -2,7 +2,7 @@
  * @file Manages Streaming APIs
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { Client, Subscription } from 'faye';
 import { registerModule } from '../jsforce';
 import Connection from '../connection';

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@
  * @file Manages asynchronous method response cache
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 /**
  * type def

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,7 +1,7 @@
 /**
  *
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import jsforce from './jsforce';
 import {
   HttpRequest,

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1,7 +1,7 @@
 /**
  *
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import xml2js from 'xml2js';
 import { Logger, getLogger } from './util/logger';
 import { StreamPromise } from './util/promise';

--- a/src/jsforce.ts
+++ b/src/jsforce.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import VERSION from './VERSION';
 import Connection from './connection';
 import OAuth2 from './oauth2';

--- a/src/query.ts
+++ b/src/query.ts
@@ -2,7 +2,7 @@
  * @file Manages query for records in Salesforce
  * @author Shinichi Tomita <shinichi.tomita@gmail.com>
  */
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { Logger, getLogger } from './util/logger';
 import RecordStream, { Serializable } from './record-stream';
 import Connection from './connection';

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
 import fetch from 'node-fetch';
 import AbortController from 'abort-controller';


### PR DESCRIPTION
This fix is really essential since `Connection`  class is now missing `on`, `off`, etc. functions inherited from the EventEmitter namespace.
This happened in other libraries as well (e.g. [https://github.com/geckosio/geckos.io/issues/22](https://github.com/geckosio/geckos.io/issues/22)).
I hope this could be merged quickly.
Thanks