### PR TITLE
Add PK Chunking support (Sforce-Enable-PKChunking)

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -805,30 +805,41 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
     }
   };  
   if (isChunking) {
-    var pollBatches = function(batchInfos) {
-      var batches = batchInfos
-        .filter(function(info) { return info.id != batch.id; })
-        .map(function(info) {
-          var batch = job.batch(info.id);
-          batch.poll(job.pollInterval, job.pollTimeout);
-          return batch.execute();
-        });
-      Promise.all(batches).then(function(res) {
+    var retrieveAll = function(batches) {
+      var results = Promise.all(batches.map(function(info) {
+        return job.batch(info.id).retrieve();
+      }));
+      results.then(function(res) { 
         batch.emit('response', _.flatten(res));
-      }, function(err) {
-        batch.emit('error', err);
+      }, function(err) { 
+        self.emit('error', err);
       });
-    }
-    var handleProgress = function(progress) { 
-      if (progress.state == 'NotProcessed') {
-        batch.pollStop();
-        job.list(function(err, batches) { 
-          if (!err) {
-            pollBatches(batches);
+      return results;
+    };
+    var pollBatches = function() {
+      job.list(function(err, batches) { 
+        if (!err) {
+          batches = batches.filter(function(info) { return info.id != batch.id; });
+          var allCompleted = batches.every(function(info) { return info.state == 'Completed'; });     
+          if (allCompleted) {
+            retrieveAll(batches);
           } else {
-            self.emit('error', error);
-          }   
-        });
+            var failedBatch = batches.find(function(info) { return info.state == 'Failed'; });
+            if (failedBatch) {
+              self.emit('error', new Error(failedBatch.stateMessage));
+            } else {
+              setTimeout(pollBatches, self.pollInterval);
+            }
+          }
+        } else {
+          self.emit('error', error);
+        }
+      });
+    };
+    var handleProgress = function(progress) { 
+      if (progress.state == "NotProcessed") {
+        batch.pollStop();
+        pollBatches();
       }
     };
     batch.on('progress', handleProgress);
@@ -859,9 +870,9 @@ Bulk.prototype.query = function(soql, options) {
   var dataStream = recordStream.stream('csv');
   this.load(type, "query", options, soql).then(function(results) {
     var streams = results.map(function(result) {
+      var job = self.job(result.jobId);
       return function() { 
-        return self
-          .job(result.jobId)
+        return job
           .batch(result.batchId)
           .result(result.id)
           .stream();

--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -111,7 +111,7 @@ Job.prototype.open = function(callback) {
       headers : {
         "Content-Type" : "application/xml; charset=utf-8",
         "Sforce-Enable-PKChunking": (this.options.pkChunking || this.options.chunkSize) ? 
-          "chunkSize=" + (this.options.chunkSize || 1000) : "false"
+          (this.options.chunkSize ? "chunkSize=" + this.options.chunkSize : "true"): "false"
       },
       responseType: "application/xml"
     }).then(function(res) {
@@ -808,10 +808,12 @@ Bulk.prototype._request = function(request, callback) {
  * Create and start bulkload job and batch
  *
  * @param {String} type - SObject type
- * @param {String} operation - Bulk load operation ('insert', 'update', 'upsert', 'delete', or 'hardDelete')
+ * @param {String} operation - Bulk load operation ('insert', 'update', 'upsert', 'delete', 'query', or 'hardDelete')
  * @param {Object} [options] - Options for bulk loading operation
  * @param {String} [options.extIdField] - External ID field name (used when upsert operation).
  * @param {String} [options.concurrencyMode] - 'Serial' or 'Parallel'. Defaults to Parallel.
+ * @param {Boolean} [options.pkChunking] - Enables PK Chunking for Bulk API Query. Defaults to false. Use chunkSize to change the default chunk size.
+ * @param {Number} [options.chunkSize] - Chunk size for `pkChunking`; when set forces PK Chunking to to true.
  * @param {Array.<Record>|stream.Stream|String} [input] - Input source for bulkload. Accepts array of records, CSV string, and CSV data input stream in insert/update/upsert/delete/hardDelete operation, SOQL string in query operation.
  * @param {Callback.<Array.<RecordResult>|Array.<Bulk~BatchResultInfo>>} [callback] - Callback function
  * @returns {Bulk~Batch}
@@ -851,7 +853,10 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
 /**
  * Execute bulk query and get record stream
  *
- * @param {String} soql - SOQL to execute in bulk job
+ * @param {String} soql - SOQL to execute in bulk job 
+ * @param {Object} [options] - Options for bulk loading operation
+ * @param {Boolean} [options.pkChunking] - Enables PK Chunking. Defaults to false. Use chunkSize to change de default chunk size.
+ * @param {Number} [options.chunkSize] - Chunk size for `pkChunking`; when set forces PK Chunking to to true.
  * @returns {RecordStream.Parsable} - Record stream, convertible to CSV data stream
  */
 Bulk.prototype.query = function(soql, options) {

--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -452,20 +452,6 @@ Batch.prototype.execute = function(input, callback) {
   }, function(err) {
     self._deferred.reject(err);
   });
-  this.once('batchesCreated', function(batchInfos) {
-    var batches = batchInfos
-      .filter(function(info) { return info.id != self.id; })
-      .map(function(info) {
-        var batch = self.job.batch(info.id);
-        batch.poll(self.job.pollInterval, self.job.pollTimeout);
-        return batch.execute();
-      });
-    Promise.all(batches).then(function(res) {
-      self._deferred.resolve(_.flatten(res));
-    }, function(err) {
-      self._deferred.reject(err);
-    });
-  })
   this.once('response', function(res) {
     rdeferred.resolve(res);
   });
@@ -578,7 +564,6 @@ Batch.prototype.poll = function(interval, timeout) {
   var self = this;
   var jobId = this.job.id;
   var batchId = this.id;
-  var isChunking = this.job.options.pkChunking || this.job.options.chunkSize;
 
   if (!jobId || !batchId) {
     throw new Error("Batch not started.");
@@ -606,17 +591,28 @@ Batch.prototype.poll = function(interval, timeout) {
           }
         } else if (res.state === "Completed") {
           self.retrieve();
-        } else if (res.state === "NotProcessed" || isChunking) {
-          self.getBatches();
         } else {
           self.emit('progress', res);
-          setTimeout(poll, interval);
+          if (self.pollHandle) {
+            self.pollHandle = setTimeout(poll, interval);
+          }
         }
       }
     });
   };
-  setTimeout(poll, interval);
+  this.pollHandle = setTimeout(poll, interval);
 };
+
+/**
+ * Stops polling the current batch for progress. Call this to stop `poll` and break the polling loop.
+ */
+Batch.prototype.pollStop = function() {
+  if (!this.pollHandle) {
+    throw new Error("Polling not started.");
+  }
+  clearTimeout(this.pollHandle);
+  this.pollHandle = undefined;
+}
 
 /**
  * @typedef {Object} Bulk~BatchResultInfo
@@ -672,43 +668,6 @@ Batch.prototype.retrieve = function(callback) {
     }
     self.emit('response', results);
     return results;
-  }).fail(function(err) {
-    self.emit('error', err);
-    throw err;
-  }).thenCall(callback);
-};
-
-/**
- * Get all batches in a job
- *
- * @method Bulk~Batch#getChunks
- * @param {Callback.<Array.<RecordResult>|Array.<Bulk~BatchInfo>>} [callback] - Callback function
- * @returns {Promise.<Array.<RecordResult>|Array.<Bulk~BatchInfo>>}
- */
-Batch.prototype.getBatches = function(callback) {
-  var self = this;
-  var bulk = this._bulk;
-  var jobId = this.job.id;
-  var job = this.job;
-  var batchId = this.id;
-
-  if (!jobId || !batchId) {
-    throw new Error("Batch not started.");
-  }
-
-  return job.info().then(function(jobInfo) {
-    return bulk._request({
-      method : 'GET',
-      path : "/job/" + jobId + "/batch/"
-    });
-  }).then(function(res) {
-    var batches = res['batchInfoList'].batchInfo;
-    batches = _.isArray(batches) ? batches : [ batches ];
-    self.emit('batchesCreated', batches);
-    // batches.forEach(function(info) {
-    //   self.emit('batchCreated', info);
-    // });
-    return batches;
   }).fail(function(err) {
     self.emit('error', err);
     throw err;
@@ -829,6 +788,7 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
     options = null;
   }
   var job = this.createJob(type, operation, options);
+  var isChunking = options.pkChunking || options.chunkSize;
   job.once('error', function (error) {
     if (batch) {
       batch.emit('error', error); // pass job error to batch
@@ -843,7 +803,36 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
     if (err.name !== 'PollingTimeout') {
       cleanup();
     }
-  };
+  };  
+  if (isChunking) {
+    var pollBatches = function(batchInfos) {
+      var batches = batchInfos
+        .filter(function(info) { return info.id != batch.id; })
+        .map(function(info) {
+          var batch = job.batch(info.id);
+          batch.poll(job.pollInterval, job.pollTimeout);
+          return batch.execute();
+        });
+      Promise.all(batches).then(function(res) {
+        batch.emit('response', _.flatten(res));
+      }, function(err) {
+        batch.emit('error', err);
+      });
+    }
+    var handleProgress = function(progress) { 
+      if (progress.state == 'NotProcessed') {
+        batch.pollStop();
+        job.list(function(err, batches) { 
+          if (!err) {
+            pollBatches(batches);
+          } else {
+            self.emit('error', error);
+          }   
+        });
+      }
+    };
+    batch.on('progress', handleProgress);
+  }
   batch.on('response', cleanup);
   batch.on('error', cleanupOnError);
   batch.on('queue', function() { batch.poll(self.pollInterval, self.pollTimeout); });
@@ -870,11 +859,13 @@ Bulk.prototype.query = function(soql, options) {
   var dataStream = recordStream.stream('csv');
   this.load(type, "query", options, soql).then(function(results) {
     var streams = results.map(function(result) {
-      return self
-        .job(result.jobId)
-        .batch(result.batchId)
-        .result(result.id)
-        .stream();
+      return function() { 
+        return self
+          .job(result.jobId)
+          .batch(result.batchId)
+          .result(result.id)
+          .stream();
+      };
     });
 
     joinStreams(streams).pipe(dataStream);

--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -109,7 +109,9 @@ Job.prototype.open = function(callback) {
       path : "/job",
       body : body,
       headers : {
-        "Content-Type" : "application/xml; charset=utf-8"
+        "Content-Type" : "application/xml; charset=utf-8",
+        "Sforce-Enable-PKChunking": (this.options.pkChunking || this.options.chunkSize) ? 
+          "chunkSize=" + (this.options.chunkSize || 1000) : "false"
       },
       responseType: "application/xml"
     }).then(function(res) {
@@ -450,6 +452,20 @@ Batch.prototype.execute = function(input, callback) {
   }, function(err) {
     self._deferred.reject(err);
   });
+  this.once('batchesCreated', function(batchInfos) {
+    var batches = batchInfos
+      .filter(function(info) { return info.id != self.id; })
+      .map(function(info) {
+        var batch = self.job.batch(info.id);
+        batch.poll(self.job.pollInterval, self.job.pollTimeout);
+        return batch.execute();
+      });
+    Promise.all(batches).then(function(res) {
+      self._deferred.resolve(_.flatten(res));
+    }, function(err) {
+      self._deferred.reject(err);
+    });
+  })
   this.once('response', function(res) {
     rdeferred.resolve(res);
   });
@@ -562,6 +578,7 @@ Batch.prototype.poll = function(interval, timeout) {
   var self = this;
   var jobId = this.job.id;
   var batchId = this.id;
+  var isChunking = this.job.options.pkChunking || this.job.options.chunkSize;
 
   if (!jobId || !batchId) {
     throw new Error("Batch not started.");
@@ -589,6 +606,8 @@ Batch.prototype.poll = function(interval, timeout) {
           }
         } else if (res.state === "Completed") {
           self.retrieve();
+        } else if (res.state === "NotProcessed" || isChunking) {
+          self.getBatches();
         } else {
           self.emit('progress', res);
           setTimeout(poll, interval);
@@ -653,6 +672,43 @@ Batch.prototype.retrieve = function(callback) {
     }
     self.emit('response', results);
     return results;
+  }).fail(function(err) {
+    self.emit('error', err);
+    throw err;
+  }).thenCall(callback);
+};
+
+/**
+ * Get all batches in a job
+ *
+ * @method Bulk~Batch#getChunks
+ * @param {Callback.<Array.<RecordResult>|Array.<Bulk~BatchInfo>>} [callback] - Callback function
+ * @returns {Promise.<Array.<RecordResult>|Array.<Bulk~BatchInfo>>}
+ */
+Batch.prototype.getBatches = function(callback) {
+  var self = this;
+  var bulk = this._bulk;
+  var jobId = this.job.id;
+  var job = this.job;
+  var batchId = this.id;
+
+  if (!jobId || !batchId) {
+    throw new Error("Batch not started.");
+  }
+
+  return job.info().then(function(jobInfo) {
+    return bulk._request({
+      method : 'GET',
+      path : "/job/" + jobId + "/batch/"
+    });
+  }).then(function(res) {
+    var batches = res['batchInfoList'].batchInfo;
+    batches = _.isArray(batches) ? batches : [ batches ];
+    self.emit('batchesCreated', batches);
+    // batches.forEach(function(info) {
+    //   self.emit('batchCreated', info);
+    // });
+    return batches;
   }).fail(function(err) {
     self.emit('error', err);
     throw err;
@@ -798,7 +854,7 @@ Bulk.prototype.load = function(type, operation, options, input, callback) {
  * @param {String} soql - SOQL to execute in bulk job
  * @returns {RecordStream.Parsable} - Record stream, convertible to CSV data stream
  */
-Bulk.prototype.query = function(soql) {
+Bulk.prototype.query = function(soql, options) {
   var m = soql.replace(/\([\s\S]+\)/g, '').match(/FROM\s+(\w+)/i);
   if (!m) {
     throw new Error("No sobject type found in query, maybe caused by invalid SOQL.");
@@ -807,7 +863,7 @@ Bulk.prototype.query = function(soql) {
   var self = this;
   var recordStream = new RecordStream.Parsable();
   var dataStream = recordStream.stream('csv');
-  this.load(type, "query", soql).then(function(results) {
+  this.load(type, "query", options, soql).then(function(results) {
     var streams = results.map(function(result) {
       return self
         .job(result.jobId)


### PR DESCRIPTION
This PR adds support for PK Chunking (sending the `Sforce-Enable-PKChunking` header) for bulk queries. Three years ago there was a similar PR which right now seems to much out of sync with the master branch to merge. _Note this PR was not based on the previous PR but created from scratch._

The main changes are in the `load` on the `bulk` prototype. It works by allowing to pass an optional options-object as parameter to the `query` function. The two additional options that can be passed:
1. `options.pkChunking` Sets the `Sforce-Enable-PKChunking` to true when `options.chunkSize` is not passed.
2. `options.chunkSize` Sets the `Sforce-Enable-PKChunking`  with a `chunkSize`.

If you set `options.chunkSize` `options.pkChunking` is automatically set to true; they are separate options to allow for using pkChunking with the default chunk size. 

In the `load` function we detect based on the job options if we are dealing with a chunked or a normal batch. If pkCunking is active we wait for the initial batch to get updated to state `NotProcessed`. Once the initial batch is `NotProcessed` we will retrieve the chunked batches (using `job.list`) and poll each batch (chunk) separately. Once _all_ chunks in the job are completed the initial batch emits a response event which then ensures the job is cleaned up and the results are returned. 

The chunks can subsequently be retrieved and made lazy using the lazy-loading feature of the mulitstream package. This prevents the streams from closing before they are even read.
 