### PR TITLE
Fix  custom type definition resolution for faye

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+import './typings/faye';
+import jsforce from './lib/index';
+export * from './lib/index';
+export default jsforce;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "./browser/request": "./browser/browser/request.js",
     "./browser/request.js": "./browser/browser/request.js"
   },
-  "types": "./lib/index",
+  "types": "./index",
   "scripts": {
     "clean": "rimraf lib/* module/* browser/*",
     "build": "run-s build:transpile build:bundle",
@@ -67,7 +67,8 @@
     "module",
     "src",
     "typings",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">=8.0"


### PR DESCRIPTION
Module `faye` has no type definition so the jsforce has its own custom type definition in `typings/faye`, but the packaged npm lib will not resolve unless the developer specifies the typesRoot path in compiler config. Include the reference in the entry file to force it to load.