### PR TITLE
Fix unresolved type definition resolutions

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1,0 +1,4 @@
+import '../typings';
+import jsforce from '../lib/core';
+export * from '../lib/core';
+export default jsforce;

--- a/core/package.json
+++ b/core/package.json
@@ -2,5 +2,5 @@
   "main": "../lib/core",
   "module": "../module/core",
   "browser": "../browser/core",
-  "types": "../lib/core"
+  "types": "./index"
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import './typings/faye';
+import './typings';
 import jsforce from './lib/index';
 export * from './lib/index';
 export default jsforce;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,7 +4415,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/multistream/-/multistream-2.1.1.tgz",
       "integrity": "sha512-PqavtNFnMyXRZS5vuW16wMOKeJUCD5PIGHdNBHzF5Urjncsij90hRQ82Wcy9+uSdnmrR2Gfao6xoJVq1wAWzbA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -4423,14 +4422,12 @@
     "@types/node": {
       "version": "12.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.9.tgz",
-      "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q==",
-      "dev": true
+      "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -4440,7 +4437,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -5302,8 +5298,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -6453,7 +6448,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -7012,8 +7006,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -13303,14 +13296,12 @@
     "mime-db": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
-      "dev": true
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
     },
     "mime-types": {
       "version": "2.1.25",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
       "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
-      "dev": true,
       "requires": {
         "mime-db": "1.42.0"
       }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@babel/runtime-corejs3": "^7.12.5",
+    "@types/node": "^12.19.9",
     "abort-controller": "^3.0.0",
     "base64url": "^3.0.1",
     "commander": "^4.0.1",
@@ -111,7 +112,6 @@
     "@types/inquirer": "^6.5.0",
     "@types/jest": "^26.0.16",
     "@types/multistream": "^2.1.1",
-    "@types/node": "^12.19.9",
     "@types/node-fetch": "^2.5.7",
     "@types/puppeteer": "^5.4.0",
     "@types/through2": "^2.0.34",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,1 @@
+import './faye';


### PR DESCRIPTION
When the lib user project has setting of `tsconfig.json` with `skipLibCheck` = false, it raises error like 

```
node_modules/jsforce/lib/api/bulk.d.ts:6:30 - error TS2307: Cannot find module 'events' or its corresponding type declarations.

6 import { EventEmitter } from 'events';
                               ~~~~~~~~

node_modules/jsforce/lib/api/bulk.d.ts:7:44 - error TS2307: Cannot find module 'stream' or its corresponding type declarations.

7 import { Duplex, Readable, Writable } from 'stream';
                                             ~~~~~~~~
```

This PR fixes it by including the type definition lib `@types/node` to`dependencies`, instead of `devDependencies`.

Additionally, it also fixes the private type definitions in `./typings` will not be loaded when the lib is imported from `jsforce/core`, not from 'jsforce'.
