### PR TITLE
Skip prefixing instance URL if it is already prefixed

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -760,6 +760,9 @@ export class Connection<S extends Schema = Schema> extends EventEmitter {
    */
   _normalizeUrl(url: string) {
     if (url[0] === '/') {
+      if (url.indexOf(this.instanceUrl + '/services/') === 0) {
+        return url;
+      }
       if (url.indexOf('/services/') === 0) {
         return this.instanceUrl + url;
       }


### PR DESCRIPTION
Fix missing URL error in Visualforce in experience cloud, which requires sub directory path in instance URL, like `/portal` or `/community`.