### PR TITLE
Expose the HTTP body on the Error object in case there are multiple errors

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -249,6 +249,7 @@ HttpApi.prototype.getError = function(response, body) {
   };
   var err = new Error(error.message);
   err.name = error.errorCode;
+  err.body = body || this.parseResponseBody(response)
   for (var key in error) { err[key] = error[key]; }
   return err;
 };


### PR DESCRIPTION
Validation Errors usually have multiple errors as an array. Currently JSforce only exposes the first one.
By attaching the body to the error, it is possible to at least handle multiple errors in userland.