### PR TITLE
changed 'then' to 'than' and changed '/' to '.' at end of README.md line 56

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You will also need to install the JsforceTestSuite package, which can be done by
 
     SF_USERNAME=myusername SF_PASSWORD=password+securityToken ./test/bin/org-setup
 
-You may need to run this more then once if you encounter timeouts or dropped connections/
+You may need to run this more than once if you encounter timeouts or dropped connections.
 
 Finally, to run the tests simply do:
 


### PR DESCRIPTION
Patches a minor grammar error in the README. "Then" was used when 'than" was needed. Also, there was a slash at the end of the line that didn't seem to serve any purpose but to end the sentence, so I suggest changing it to a period.