### PR TITLE
fix timeout oauth2 test for web server flow when it should receive authz code

### DIFF
--- a/test/helper/webauth/index.ts
+++ b/test/helper/webauth/index.ts
@@ -36,6 +36,9 @@ async function loginAndApprove(
   } else if (url.indexOf('/setup/secur/RemoteAccessErrorPage.apexp') > 0) {
     // authorization error
     throw new Error('invalid authorization error');
+  } else if (url.endsWith('salesforce.com/')) {
+    // authorization error
+    throw new Error('invalid authorization error');
   } else {
     await page.waitForTimeout(1000);
     return loginAndApprove(page, username, password);


### PR DESCRIPTION
I tried running the OAuth2 tests to verify that I provided the right config but I noticed that it timed out each time on the first assertion. 

I investigated the problem through debugger and found out that none conditions at `loginAndApprove` are being hit so it jumps to else each time and keep on looping but I assumed that `page.waitForTimeout(1000)` would cause the script from exiting but it did not seem to be the case. 

The condition I provided is hit because `SF_LOGIN_URL` wasn't set properly so the URL of the page is the login url. In my case I was trying to use sandbox credentials and I did not set the right login url to realise that something was off

Feel free to suggest me a better fix or if I might have not solved it completely as I am looking to learn from this PR. 

EDIT: I had to add that I am looking forward to work on 2.0 as I have an upcoming project and I really want to use Typescript for it. 