### PR TITLE
fix: support HTTPS proxy env

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -21,7 +21,7 @@ function normalizeApiHost(apiHost: string) {
 }
 
 setDefaults({
-  httpProxy: process.env.HTTP_PROXY ?? undefined,
+  httpProxy: process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? undefined,
   timeout: process.env.HTTP_TIMEOUT
     ? parseInt(process.env.HTTP_TIMEOUT, 10)
     : undefined,


### PR DESCRIPTION
sfdx issue with repro: https://github.com/forcedotcom/cli/issues/1626

closes https://github.com/jsforce/jsforce/issues/626

NOTE: this does not provide support for both HTTPS and HTTP proxies simultaneously.  Code in jsforce is using HTTPS
https://github.com/jsforce/jsforce/blob/90a5423c43da3758bdcefb32b17aaa1dc09828a9/src/request.ts#L38

but grabs the env named `HTTP_PROXY`
https://github.com/jsforce/jsforce/blob/90a5423c43da3758bdcefb32b17aaa1dc09828a9/src/transport.ts#L24

this lets you use either, with a preference for `HTTPS_PROXY`

@[W-11426296](https://gus.lightning.force.com/a07EE000011OdYaYAK)@