### PR TITLE
Fix URL Encoding for Upsert External ID

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -163,10 +163,10 @@ var Connection = module.exports = function(options) {
   }
 
   var cacheOptions = {
-    key: function(type) { 
-      return type 
+    key: function(type) {
+      return type
         ? type.type ? "describe." + type.type : "describe." + type
-        : "describe"; 
+        : "describe";
     }
   };
   this.describe$ = this.cache.makeCacheable(this.describe, this, cacheOptions);
@@ -178,7 +178,7 @@ var Connection = module.exports = function(options) {
     key: function(options) {
       var types = options.types;
       var autofetch = options.autofetch || false;
-      var typesToFetch = types.length > MAX_BATCH_REQUESTS 
+      var typesToFetch = types.length > MAX_BATCH_REQUESTS
         ? (autofetch ? types : types.slice(0, MAX_BATCH_REQUESTS))
         : types;
       var keys = [];
@@ -1007,7 +1007,7 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
       delete record.type;
       delete record.attributes;
 
-      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, extId ].join('/');
+      var url = [ self._baseUrl(), "sobjects", sobjectType, extIdField, encodeURI(extId) ].join('/');
       return self.request({
         method : 'PATCH',
         url : url,
@@ -1162,7 +1162,7 @@ Connection.prototype.search = function(sosl, callback) {
  */
 /**
  * Parameter for describeSObject call
- * 
+ *
  * @typedef {Object} DescribeSObjectOptions
  */
 /**
@@ -1189,8 +1189,8 @@ Connection.prototype.describe =
 Connection.prototype.describeSObject = function(type, callback) {
   var name = type.type ? type.type : type;
   var url = [ this._baseUrl(), "sobjects", name, "describe" ].join('/');
-  var headers = type.ifModifiedSince 
-    ? { 'If-Modified-Since': type.ifModifiedSince } 
+  var headers = type.ifModifiedSince
+    ? { 'If-Modified-Since': type.ifModifiedSince }
     : {};
   return this.request({
     method: 'GET',
@@ -1212,7 +1212,7 @@ Connection.prototype.describeSObject = function(type, callback) {
  */
 /**
  * Parameter for describeSObject call
- * 
+ *
  * @typedef {Object} BatchDescribeSObjectOptions
  */
 /**
@@ -1221,11 +1221,11 @@ Connection.prototype.describeSObject = function(type, callback) {
  * @method Connection#batchDescribeSObjects
  * @param {BatchDescribeSObjectOptions} options - options for function
  * @param {String[]} options.types - names of objects to fetch
- * @param {Boolean} options.autofetch - whether to automatically fetch metadata for large numbers of 
- *                         types (one batch request returns a maximum of 25 results); when true, will make 
- *                         subsequent requests until all object metadata is fetched; when false (default), 
+ * @param {Boolean} options.autofetch - whether to automatically fetch metadata for large numbers of
+ *                         types (one batch request returns a maximum of 25 results); when true, will make
+ *                         subsequent requests until all object metadata is fetched; when false (default),
  *                         will make one batch request for maximum of 25 results
- * @param {number} options.maxConcurrentRequests - maximum number of concurrent requests sent to the org; 
+ * @param {number} options.maxConcurrentRequests - maximum number of concurrent requests sent to the org;
  *                         default and maximum is 15
  * @param {Callback.<DescribeSObjectResult[]>} [callback] - Callback function
  * @returns {Promise.<DescribeSObjectResult[]>}
@@ -1236,11 +1236,11 @@ Connection.prototype.describeSObject = function(type, callback) {
  * @method Connection#batchDescribe
  * @param {BatchDescribeSObjectOptions} options - options for function
  * @param {String[]} options.types - names of objects to fetch
- * @param {Boolean} options.autofetch - whether to automatically fetch metadata for large numbers of 
- *                         types (one batch request returns a maximum of 25 results); when true, will make 
- *                         subsequent requests until all object metadata is fetched; when false (default), 
+ * @param {Boolean} options.autofetch - whether to automatically fetch metadata for large numbers of
+ *                         types (one batch request returns a maximum of 25 results); when true, will make
+ *                         subsequent requests until all object metadata is fetched; when false (default),
  *                         will make one batch request for maximum of 25 results
- * @param {number} options.maxConcurrentRequests - maximum number of concurrent requests sent to the org; 
+ * @param {number} options.maxConcurrentRequests - maximum number of concurrent requests sent to the org;
  *                         default and maximum is 15
  * @param {Callback.<DescribeSObjectResult[]>} [callback] - Callback function
  * @returns {Promise.<DescribeSObjectResult[]>}
@@ -1334,7 +1334,7 @@ Connection.prototype.doBatchDescribeRequest = function(types) {
         if (Array.isArray(subResp.result)) {
           if (subResp.result[0].errorCode && subResp.result[0].message) {
             this._logger.error(
-              'Error: ' + subResp.result[0].errorCode + ' ' +  
+              'Error: ' + subResp.result[0].errorCode + ' ' +
               subResp.result[0].message + ' - ' + typesToFetch[i]
             );
           }
@@ -1344,7 +1344,7 @@ Connection.prototype.doBatchDescribeRequest = function(types) {
       }
     }
     return Promise.resolve(sobjects);
-  }); 
+  });
 }
 
 /**
@@ -1580,7 +1580,7 @@ Connection.prototype.loginBySoap = function(username, password, callback) {
 };
 
 /**
- * Logout the current session 
+ * Logout the current session
  *
  * @param {Boolean} [revoke] - Revokes API Access if set to true
  * @param {Callback.<undefined>} [callback] - Callback function


### PR DESCRIPTION
Adding URL encoding to the external ID used in a REST upsert call, as this can include "/" which will interpret as additional path without being encoded. 