### PR TITLE
Adding headers to identity get.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1399,7 +1399,7 @@ Connection.prototype.identity = function(options, callback) {
     this.request({ method: 'GET', url: this._baseUrl(), headers: options.headers })
   ).then(function(res) {
     var url = res.identity;
-    return self.request({ method: 'GET', url: url });
+    return self.request({ method: 'GET', url: url, headers: options.headers });
   }).then(function(res) {
     self.userInfo = {
       id: res.user_id,


### PR DESCRIPTION
Recently I worked with Salesforce on trying to get this work while impersonating a user. They explained that I would need to send the RSID cookie with the get request to get the user information of who you are impersonating. Otherwise the server returns the logout page.

Example of returned error if the RSID cookie is not sent with the identity get. <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><script type="text/javascript">setTimeout(function(){var redirectUrl = 'https://www.salesforce.com';if(window.localStorage && window.localStorage.getItem && window.localStorage.getItem('logoutUrl')){redirectUrl = window.localStorage.getItem('logoutUrl');}window.location =  redirectUrl;},500);</script></head><body id="logoutBody" onload="if(this.bodyOnLoad) bodyOnLoad();" onunload="if(this.bodyOnUnload) bodyOnUnload();"><!-- Logout Page --></body></html>