### PR TITLE
Keep connection alive for 1 minute

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -14,7 +14,11 @@ var request = require('request'),
 // set options if defaults setting is available in request, which is not available in xhr module.
 if (request.defaults) {
   var defaults = {
-    followAllRedirects: true
+    followAllRedirects: true,
+    agentOptions: {
+      keepAlive: true,
+      keepAliveMsecs: 60000
+    }
   };
   if (process.env.HTTP_PROXY) {
     defaults.proxy = process.env.HTTP_PROXY;


### PR DESCRIPTION
Keep connection alive for 1 minute to improve overall performance. Default behavior was to open a new socket for each request.

Related: #1294