### PR TITLE
Fix for jsforce metadata retrieve error: #1302

### DIFF
--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -770,6 +770,9 @@ RetrieveResultLocator.prototype.stream = function() {
     self.complete(function(err, result) {
       if (err) {
         resultStream.emit('error', err);
+      }
+      else if (result.success == 'false'){
+         resultStream.emit('error', result);
       } else {
         resultStream.push(Buffer.from(result.zipFile, 'base64'));
         resultStream.push(null);


### PR DESCRIPTION
 [ERR_INVALID_ARG_TYPE]  error fix 
