### PR TITLE
Fixes bulk.query error handling

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -817,7 +817,7 @@ Bulk.prototype.query = function(soql) {
     });
 
     joinStreams(streams).pipe(dataStream);
-  }).fail(function(err) {
+  }).catch(function(err) {
     recordStream.emit('error', err);
   });
   return recordStream;


### PR DESCRIPTION
Steps to reproduce:

1 - run the following function with the following query `SELECT FIELDS(ALL) FROM Product2 LIMIT 200` and using an API version that does not work with `FIELDS(ALL)`

````js
function(conn, query, outputPath){
  return new Promise((resolve, reject) => {
      const readStream = conn.bulk.query(query).stream();
      const writeStream = fs.createWriteStream(outputPath);
      const errors = [];
  
      readStream.on('error', e => {
        console.log(e);
        errors.push(e);
      });
  
      readStream.on('end', () => {
        if(errors.length) return reject({
          success: false,
          message: 'error while exporting data to file',
          errors
        })
        
        resolve({
          success: true,
          message: 'success while exporting data to file',
        });
      });
  
      readStream.pipe(writeStream);
      
    });
}
````

2. confirm that bulk query emmits an error event and that the read stream error handler isn't called.



````shell
"Error: InvalidBatch : Failed to process query: UNSUPPORTED_API_VERSION: SELECT FIELDS(All) FROM Product2 LIMIT        ^ ERROR at Row:1:Column:8 The SOQL FIELDS function is not supported in this version of the API\n\tat /Users/allanoricil/CPQ-Extensions/packages/cpq-devkit-sf/out/main.js:64698:37\n\tat /Users/allanoricil/CPQ-Extensions/packages/cpq-devkit-sf/out/main.js:4067:13\n\tat process.processTicksAndRejections (node:internal/process/task_queues:78:11)"
````
Here you can see that the error event is emmited. But for an unknown reason the `readStream.on('error')` handler isn't called.
![image](https://user-images.githubusercontent.com/55927613/224518918-a8080144-c474-4c4e-a13b-05694ab1ca32.png)


3. change `fail` to `catch`, repeat the above steps and confirm that now the error handler from the readSstream is called. This means that the event was succesfully emmited, and that the call stack wasn't killed.

In this image you can see that the `readStream.on('error')` was called.
![image](https://user-images.githubusercontent.com/55927613/224519106-6b4f2320-bb26-49c6-b015-f374309c1dab.png)


### Before
error event is emitted and the stream handler is not called

### After 

error event is emmited and the stream handler is called

### System Information

node 16.19.1
jsforce: 1.9.1

![image](https://user-images.githubusercontent.com/55927613/224518817-e3d18197-a344-4665-9c69-0d5ec47572bc.png)
