### PR TITLE
Standardize bulk 1 and 2 APIs expoing "streams" to bulk2.query

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '@babel/plugin-proposal-optional-chaining',
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-async-generator-functions',
     [
       '@babel/plugin-transform-runtime',
       {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "devDependencies": {
     "@babel/cli": "^7.12.8",
     "@babel/core": "^7.12.9",
+    "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
     "@babel/plugin-proposal-optional-chaining": "^7.12.7",

--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -1119,7 +1119,8 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
   jobInfo: Partial<JobInfoV2> | undefined;
   locator: Optional<string>;
   finished: boolean = false;
-  numberOfRecordsProcessed: number;
+  numberRecordsRetrieved: number;
+  numberBatchesProcessed: number;
 
   constructor(options: CreateQueryJobV2Options<S>) {
     super();
@@ -1128,7 +1129,8 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
     this.#query = options.query;
     this.#pollingOptions = options.pollingOptions;
     this.#maxRecords = options.maxRecords!;
-    this.numberOfRecordsProcessed = 0;
+    this.numberRecordsRetrieved = 0;
+    this.numberBatchesProcessed = 0;
     // default error handler to keep the latest error
     this.on('error', (error) => (this.#error = error));
   }
@@ -1273,7 +1275,8 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
           Accept: 'text/csv',
         },
       });
-      this.numberOfRecordsProcessed += results.length;
+      this.numberRecordsRetrieved += results.length;
+      this.numberBatchesProcessed++;
       yield results;
     } while (this.locator !== 'null');
   }

--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -1112,20 +1112,20 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
   readonly #operation: QueryOperation;
   readonly #query: string;
   readonly #pollingOptions: BulkV2PollingOptions;
-  readonly #maxRecords: number;
+  readonly #maxRecords: number = 10000;
   #error: Error | undefined;
   jobInfo: Partial<JobInfoV2> | undefined;
   locator: Optional<string>;
   finished: boolean = false;
   numberOfRecordsProcessed: number;
-
+  
   constructor(options: CreateQueryJobV2Options<S>) {
     super();
     this.#connection = options.connection;
     this.#operation = options.operation;
     this.#query = options.query;
     this.#pollingOptions = options.pollingOptions;
-    this.#maxRecords = options.maxRecords || 10000;
+    this.#maxRecords = options.maxRecords!;
     this.numberOfRecordsProcessed = 0;
     // default error handler to keep the latest error
     this.on('error', (error) => (this.#error = error));

--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -214,6 +214,8 @@ type BulkV2PollingOptions = {
   pollTimeout: number;
 };
 
+export const MAX_RECORDS = 10000;
+
 /**
  * Class for Bulk API Job
  */
@@ -1112,13 +1114,13 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
   readonly #operation: QueryOperation;
   readonly #query: string;
   readonly #pollingOptions: BulkV2PollingOptions;
-  readonly #maxRecords: number = 10000;
+  readonly #maxRecords: number = MAX_RECORDS;
   #error: Error | undefined;
   jobInfo: Partial<JobInfoV2> | undefined;
   locator: Optional<string>;
   finished: boolean = false;
   numberOfRecordsProcessed: number;
-  
+
   constructor(options: CreateQueryJobV2Options<S>) {
     super();
     this.#connection = options.connection;

--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -1115,7 +1115,6 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
   readonly #query: string;
   readonly #pollingOptions: BulkV2PollingOptions;
   readonly #maxRecords: number | undefined;
-  #queryResults: Record[] | undefined;
   #error: Error | undefined;
   jobInfo: Partial<JobInfoV2> | undefined;
   locator: Optional<string>;
@@ -1257,7 +1256,7 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
       url.searchParams.set('locator', this.locator);
     }
     if (this.#maxRecords) {
-      url.searchParams.set('maxRecords', `${this.#maxRecords}`);
+      url.searchParams.set('maxRecords', this.#maxRecords.toString());
     }
 
     return url.toString();

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -6,6 +6,7 @@ import ConnectionManager from './helper/connection-manager';
 import config from './config';
 import { isObject, isString } from './util';
 import { isNodeJS } from './helper/env';
+import { MAX_RECORDS } from '../src/api/bulk';
 
 const connMgr = new ConnectionManager(config);
 const conn = connMgr.createConnection();
@@ -151,7 +152,7 @@ it('should bulk delete with empty input and not raise client input error', async
 });
 
 // /*------------------------------------------------------------------------*/
-if(isNodeJS()){
+if (isNodeJS()) {
   it('should bulk insert from file and return inserted results', async () => {
     const csvStream = fs.createReadStream(
       path.join(__dirname, 'data/Account.csv'),
@@ -204,15 +205,16 @@ if(isNodeJS()){
     const { records, numberOfBatchesProcessed } = await getRecords(readStream);
 
     assert.ok(records.length === count);
-    assert.ok(numberOfBatchesProcessed === 1);
+    assert.ok(numberOfBatchesProcessed === Math.ceil(count / MAX_RECORDS));
   });
 
   it('should read 500 records per batch', async () => {
+    const maxRecords = 500;
     const count = await conn.sobject(config.bigTable).count({});
     const queryJob = await conn.bulk2.query(
       `SELECT Id, Name FROM ${config.bigTable}`,
       {
-        maxRecords: 500,
+        maxRecords,
       },
     );
 
@@ -220,7 +222,7 @@ if(isNodeJS()){
     const { records, numberOfBatchesProcessed } = await getRecords(readStream);
 
     assert.ok(records.length === count);
-    assert.ok(numberOfBatchesProcessed === 5);
+    assert.ok(numberOfBatchesProcessed === Math.ceil(count / maxRecords));
   });
 }
 


### PR DESCRIPTION
## BEFORE 
soql queries that return huge number of rows could throw `FATAL Error ... Javascript heap out of memory` because `bulk2.query` stores all records in memory.

![image](https://user-images.githubusercontent.com/55927613/227099188-e16f7407-064a-4950-99f1-ee7778816a37.png)


## AFTER

query results can be retrieved in batches with size equal to the value passed to `maxRecords`. 

obs: there isn't a real stream from Salesforce to jsforce because bulk api v2 does not offer it. These changes are just sending pages to a stream so that the api for v2 is the same as v1.

obs: page results are not stored in memory unless the developer chooses it by concatenation results from every page

````js
import { pipeline } from 'stream/promises';
import { Connection } from 'jsforce';

try {
    const conn = new Connection(CONFIG);
    
    //the default value for maxRecords is 10000
    const queryJob = await conn.bulk2.query(
      `SELECT Id, Name FROM Account`,
    );
    const readStream = queryJob.stream();
    const writeStream = fs.createWriteStream(path.resolve(PATH));


  await pipeline(readStream, writeStream);
}catch(e){
   throw new Error('Something went wrong');
}
````

or, if developers want to gather all records in memory before doing something with them
````js
import { pipeline } from 'stream/promises';
import { Connection } from 'jsforce';


function getRecords(readStream){
   return new Promise((resolve, reject) => {
       const records = [];
       readStream
        .on('data', (data) => records = records.concat(data))
        .on('error', (error) => reject(e))
        .on('close', () => resolve(records))
   });
}

try {
    const conn = new Connection(CONFIG);
    const records = [];
    const queryJob = await conn.bulk2.query(
      `SELECT Id, Name FROM Account`,
    );
    const readStream = queryJob.stream();
    const records = await getRecords(readStream);
}catch(e){
   throw new Error('Something went wrong');
}
````