### PR TITLE
[v2.0] Add missing type prop not matching with api/soap/schema.ts 

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -219,6 +219,7 @@ type DescribeGlobalSObjectResult = {
   deprecatedAndHidden: boolean;
   feedEnabled: boolean;
   hasSubtypes: boolean;
+  idEnabled: boolean;
   isInterface: boolean;
   isSubtype: boolean;
   keyPrefix: Optional<string>;


### PR DESCRIPTION
In jsforce@v2.0, defined DescribeGlobalSObjectResult type in [src/types/common.ts](https://github.com/jsforce/jsforce/blob/74d4dd37f385f2ae1ab3af1747793afb853755d1/src/types/common.ts#L212) doesn't have idEnabled property while it is defined in [src/api/soap/schema.ts](https://github.com/jsforce/jsforce/blob/74d4dd37f385f2ae1ab3af1747793afb853755d1/src/api/soap/schema.ts#L605), which is causing type error in Typescript.