### PR TITLE
 chore(ci): add manual release workflow

### DIFF
--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -1,0 +1,40 @@
+name: manual release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
+        # overriding some of the basic behaviors to just get the changelog
+        with:
+          git-user-name: svc-cli-bot
+          git-user-email: svc_cli_bot@salesforce.com
+          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          output-file: false
+          pre-commit: ./scripts/build.js
+          pre-release: true
+          pre-release-identifier: "beta"
+          # always do the release, even if there are no semantic commits
+          skip-on-empty: false
+          tag-prefix: ''
+      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+        id: packageVersion
+        with:
+          path: 'package.json'
+          prop_path: 'version'
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.packageVersion.outputs.prop }}
+          release_name: ${{ steps.packageVersion.outputs.prop }}
+          prerelease: true

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,0 +1,33 @@
+name: publish
+
+on:
+  release:
+    types: [released]
+  # support manual release in case something goes wrong and needs to be repeated or tested
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag that needs to publish
+        type: string
+        required: true
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts
+          cache: npm
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Install dependencies
+        run: npm install 
+      - name: Build
+        run: npm run clean && npm run build
+      - name: Publish
+        run: npm publish --tag beta
+

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,10 @@
+const { exec } = require('node:child_process');
+
+exports.preCommit = async (props) => {
+  exec('npm run build', (error, _, _) => {
+    if (error) {
+      throw error
+    }
+  })
+}
+


### PR DESCRIPTION
Add a GHA workflow to do releases from CI via a manual trigger.

It has a few specific values like `pre-release-identifier` that should be deleted once v2 is GA.
The test pipeline still runs on Circle and doesn't have any integration with this, so once you merge a PR you need to manually trigger a release from the actions tab.

**TODO**:
1) add npm and GH tokens