### PR TITLE
chore: fix types for bundling

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -21,7 +21,7 @@ import {
 import { QueryExplainResult } from '../query';
 
 /*----------------------------------------------------------------------------------*/
-export {
+export type {
   ReportMetadata,
   ReportExecuteResult,
   ReportRetrieveResult,

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,11 +18,11 @@ export {
   VERSION,
   SfDate as Date,
   SfDate,
-  Registry,
   BrowserClient,
   RecordReference,
   RecordStream,
   registry,
   browser,
 };
+export type { Registry };
 export default jsforce;

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,4 +1,4 @@
-import { Registry } from './types';
+import type { Registry } from './types';
 import { FileRegistry } from './file';
 import { SfdxRegistry } from './sfdx';
 import { EmptyRegistry } from './empty';
@@ -15,5 +15,5 @@ try {
 }
 
 export default registry;
-
-export { Registry, FileRegistry, SfdxRegistry, EmptyRegistry };
+export type { Registry };
+export { FileRegistry, SfdxRegistry, EmptyRegistry };


### PR DESCRIPTION
add type to type only imports and exports

This is to play nice with bundlers.
babel removes the type info from the types files since js does not care about them.
This has the effect of having an import with no export which bundlers do not like.
You can see this most clearly in the analysis.ts file which 
is re exporting types from the types file.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export

resolves #1342