### PR TITLE
Bring back JWT OAuth2 module (as deprecated)

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -62,7 +62,6 @@ import Metadata from './api/metadata';
 import SoapApi from './api/soap';
 import Streaming from './api/streaming';
 import Tooling from './api/tooling';
-import { JwtOAuth2Config, JwtOAuth2 } from './jwtOAuth2';
 import FormData from 'form-data';
 
 /**
@@ -78,7 +77,6 @@ export type ConnectionConfig<S extends Schema = Schema> = {
   serverUrl?: string;
   signedRequest?: string;
   oauth2?: OAuth2 | OAuth2Config;
-  jwtOAuth2?: JwtOAuth2 | JwtOAuth2Config;
   maxRequest?: number;
   proxyUrl?: string;
   httpProxy?: string;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -62,6 +62,7 @@ import Metadata from './api/metadata';
 import SoapApi from './api/soap';
 import Streaming from './api/streaming';
 import Tooling from './api/tooling';
+import { JwtOAuth2Config, JwtOAuth2 } from './jwtOAuth2';
 import FormData from 'form-data';
 
 /**
@@ -77,6 +78,7 @@ export type ConnectionConfig<S extends Schema = Schema> = {
   serverUrl?: string;
   signedRequest?: string;
   oauth2?: OAuth2 | OAuth2Config;
+  jwtOAuth2?: JwtOAuth2 | JwtOAuth2Config;
   maxRequest?: number;
   proxyUrl?: string;
   httpProxy?: string;

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,6 +8,7 @@ import RecordReference from './record-reference';
 import RecordStream from './record-stream';
 
 export * from './oauth2';
+export * from './jwtOAuth2';
 export * from './connection';
 export * from './query';
 export * from './quick-action';

--- a/src/jwtOAuth2.ts
+++ b/src/jwtOAuth2.ts
@@ -1,0 +1,23 @@
+import OAuth2, { OAuth2Config } from './oauth2';
+
+export type JwtOAuth2Config = OAuth2Config & {
+  privateKey?: string;
+  privateKeyFile?: string;
+  authCode?: string;
+  refreshToken?: string;
+  loginUrl?: string;
+  username?: string;
+};
+
+export class JwtOAuth2 extends OAuth2 {
+  constructor(config: OAuth2Config) {
+    super(config);
+  }
+
+  public jwtAuthorize(innerToken: string): Promise<any> {
+    return super._postParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: innerToken,
+    });
+  }
+}

--- a/src/jwtOAuth2.ts
+++ b/src/jwtOAuth2.ts
@@ -1,16 +1,13 @@
 import OAuth2, { OAuth2Config } from './oauth2';
 
-export type JwtOAuth2Config = OAuth2Config & {
-  privateKey?: string;
-  privateKeyFile?: string;
-  authCode?: string;
-  refreshToken?: string;
-  loginUrl?: string;
-  username?: string;
-};
-
+/**
+ * @deprecated
+ */
 export class JwtOAuth2 extends OAuth2 {
   constructor(config: OAuth2Config) {
+    console.warn(
+      'JwtOAuth2 is deprecated and will be removed in next stable release, please use OAuth2 instead.',
+    );
     super(config);
   }
 


### PR DESCRIPTION
As the latest update of jsforce (beta25), which includes removal of JwtOAuth2 #1341 , `sfdx-cli` is failing for the absence of `jsforce_1.JwtOAuth2`. This will be fixed in the `sfdx-core`, but the fix is not yet merged and it requires all sfdx-cli users to update its version because the sfdx-core is depending jsforce in caret versioning (^2.0.0-beta.24), which automatically select the latest beta version.
Considering the impact of this disfunction, I would like to bring back the JwtOAuth2 module, but with deprecated warning.