### PR TITLE
feat: set content-length header

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,7 @@
 /* global jest */
 jest.setTimeout(120000);
-jest.retryTimes(3, {logErrorsBeforeRetry: true})
+
+// only retry on CI
+if (process.env.CI) {
+  jest.retryTimes(3, {logErrorsBeforeRetry: true})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.23.1",
         "@babel/runtime-corejs3": "^7.23.1",
-        "@sindresorhus/is": "^6.1.0",
+        "@sindresorhus/is": "^4",
         "@types/node": "^18.15.3",
         "abort-controller": "^3.0.0",
         "base64url": "^3.0.1",
@@ -3747,11 +3747,11 @@
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.1.0.tgz",
-      "integrity": "sha512-BuvU07zq3tQ/2SIgBsEuxKYDyDjC0n7Zir52bpHy2xnBbW81+po43aLFPLbeV3HRAheFbGud1qgcqSYfhtHMAg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.23.1",
         "@babel/runtime-corejs3": "^7.23.1",
+        "@sindresorhus/is": "^6.1.0",
         "@types/node": "^18.15.3",
         "abort-controller": "^3.0.0",
         "base64url": "^3.0.1",
@@ -3744,6 +3745,17 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.1.0.tgz",
+      "integrity": "sha512-BuvU07zq3tQ/2SIgBsEuxKYDyDjC0n7Zir52bpHy2xnBbW81+po43aLFPLbeV3HRAheFbGud1qgcqSYfhtHMAg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.1",
     "@babel/runtime-corejs3": "^7.23.1",
-    "@sindresorhus/is": "^6.1.0",
+    "@sindresorhus/is": "^4",
     "@types/node": "^18.15.3",
     "abort-controller": "^3.0.0",
     "base64url": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
     },
     "test:node": {
       "command": "jest --forceExit",
-      "dependencies": ["build:node:cjs"],
+      "dependencies": [
+        "build:node:cjs"
+      ],
       "files": [
         "test/**/*.ts",
         "jest.setup.js",
@@ -207,6 +209,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.1",
     "@babel/runtime-corejs3": "^7.23.1",
+    "@sindresorhus/is": "^6.1.0",
     "@types/node": "^18.15.3",
     "abort-controller": "^3.0.0",
     "base64url": "^3.0.1",

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -185,8 +185,10 @@ export class HttpApi<S extends Schema> extends EventEmitter {
 
     const bodySize = getBodySize(request.body, headers);
 
+    const cannotHaveBody = ['GET', 'HEAD', 'OPTIONS'].includes(request.method);
+
     if (
-      request.method === 'POST' &&
+      !cannotHaveBody &&
       !!request.body &&
       !headers['transfer-encoding'] &&
       !headers['content-length'] &&

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -194,6 +194,9 @@ export class HttpApi<S extends Schema> extends EventEmitter {
       !headers['content-length'] &&
       !!bodySize
     ) {
+      this._logger.debug(
+        `missing 'content-length' header, setting it to: ${bodySize}`,
+      );
       headers['content-length'] = String(bodySize);
     }
     request.headers = headers;

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -127,22 +127,22 @@ export class HttpApi<S extends Schema> extends EventEmitter {
         // when session refresh delegate is available
         if (this.isSessionExpired(response) && refreshDelegate) {
           await refreshDelegate.refresh(requestTime);
-          // remove the `content-length` header after token refresh
-          //
-          // SOAP requests include the access token their the body,
-          // if the first req had an invalid token and jsforce successfully
-          // refreshed it we need to remove the `content-length` header
-          // so that it get's re-calculated again with the new body.
-          //
-          // REST request aren't affected by this because the access token
-          // is sent via HTTP headers
-          //
-          //
-          // `_message` is only present in SOAP requests
+          /* remove the `content-length` header after token refresh
+           *
+           * SOAP requests include the access token their the body,
+           * if the first req had an invalid token and jsforce successfully
+           * refreshed it we need to remove the `content-length` header
+           * so that it get's re-calculated again with the new body.
+           *
+           * REST request aren't affected by this because the access token
+           * is sent via HTTP headers
+           *
+           * `_message` is only present in SOAP requests
+           */
           if (
-            Object.hasOwn(request, '_message') &&
+            '_message' in request &&
             request.headers &&
-            request.headers['content-length']
+            'content-length' in request.headers
           ) {
             delete request.headers['content-length'];
           }
@@ -190,8 +190,8 @@ export class HttpApi<S extends Schema> extends EventEmitter {
     if (
       !cannotHaveBody &&
       !!request.body &&
-      !headers['transfer-encoding'] &&
-      !headers['content-length'] &&
+      !('transfer-encoding' in headers) &&
+      !('content-length' in headers) &&
       !!bodySize
     ) {
       this._logger.debug(

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -16,6 +16,7 @@ import {
   Schema,
 } from './types';
 import { createLazyStream } from './util/stream';
+import { getBodySize } from './util/get-body-size';
 
 /** @private */
 function parseJSON(str: string) {
@@ -161,6 +162,18 @@ export class HttpApi<S extends Schema> extends EventEmitter {
         callOptions.push(`${name}=${this._conn._callOptions[name]}`);
       }
       headers['Sforce-Call-Options'] = callOptions.join(', ');
+    }
+
+    const bodySize = getBodySize(request.body, headers);
+
+    if (
+      request.method === 'POST' &&
+      !!request.body &&
+      !headers['transfer-encoding'] &&
+      !headers['content-length'] &&
+      !!bodySize
+    ) {
+      headers['content-length'] = String(bodySize);
     }
     request.headers = headers;
   }

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -12,6 +12,7 @@ import {
   SoapSchemaDef,
 } from './types';
 import { isMapObject, isObject } from './util/function';
+import { getBodySize } from './util/get-body-size';
 
 /**
  *
@@ -232,6 +233,18 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
 
   /** @override */
   beforeSend(request: HttpRequest & { _message: object }) {
+    const bodySize = getBodySize(request.body, request.headers);
+
+    if (
+      request.method === 'POST' &&
+      request.headers &&
+      !request.headers['transfer-encoding'] &&
+      !request.headers['content-length'] &&
+      !!bodySize
+    ) {
+      request.headers['content-length'] = String(bodySize);
+    }
+
     request.body = this._createEnvelope(request._message);
   }
 

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -235,20 +235,23 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
   beforeSend(request: HttpRequest & { _message: object }) {
     request.body = this._createEnvelope(request._message);
 
+    const headers = request.headers || {};
+
     const bodySize = getBodySize(request.body, request.headers);
 
     if (
       request.method === 'POST' &&
-      request.headers &&
-      !request.headers['transfer-encoding'] &&
-      !request.headers['content-length'] &&
+      !('transfer-encoding' in headers) &&
+      !('content-length' in headers) &&
       !!bodySize
     ) {
       this._logger.debug(
         `missing 'content-length' header, setting it to: ${bodySize}`,
       );
-      request.headers['content-length'] = String(bodySize);
+      headers['content-length'] = String(bodySize);
     }
+
+    request.headers = headers;
   }
 
   /** @override **/

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -244,6 +244,9 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
       !request.headers['content-length'] &&
       !!bodySize
     ) {
+      this._logger.debug(
+        `missing 'content-length' header, setting it to: ${bodySize}`,
+      );
       request.headers['content-length'] = String(bodySize);
     }
   }

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -233,6 +233,8 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
 
   /** @override */
   beforeSend(request: HttpRequest & { _message: object }) {
+    request.body = this._createEnvelope(request._message);
+
     const bodySize = getBodySize(request.body, request.headers);
 
     if (
@@ -244,8 +246,6 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
     ) {
       request.headers['content-length'] = String(bodySize);
     }
-
-    request.body = this._createEnvelope(request._message);
   }
 
   /** @override **/

--- a/src/util/get-body-size.ts
+++ b/src/util/get-body-size.ts
@@ -2,10 +2,10 @@ import type { Readable } from 'node:stream';
 import { HttpBody } from '../types';
 import is from '@sindresorhus/is';
 
-export async function getBodySize(
+export function getBodySize(
   body: HttpBody | undefined,
   headers: { [name: string]: string } | undefined,
-): Promise<number | undefined> {
+): number | undefined {
   function isFormData(body: unknown): body is FormData {
     return is.nodeStream(body) && is.function_((body as FormData).getBoundary);
   }

--- a/src/util/get-body-size.ts
+++ b/src/util/get-body-size.ts
@@ -30,7 +30,7 @@ export function getBodySize(
     return body.length;
   }
   if (isFormData(body)) {
-    return body.toString().length;
+    return body.getLengthSync();
   }
 
   return undefined;

--- a/src/util/get-body-size.ts
+++ b/src/util/get-body-size.ts
@@ -1,14 +1,13 @@
 import type { Readable } from 'node:stream';
 import { HttpBody } from '../types';
+import is from '@sindresorhus/is';
 
 export async function getBodySize(
   body: HttpBody | undefined,
   headers: { [name: string]: string } | undefined,
 ): Promise<number | undefined> {
-  const { default: is } = await import('@sindresorhus/is');
-
   function isFormData(body: unknown): body is FormData {
-    return is.nodeStream(body) && is.function((body as FormData).getBoundary);
+    return is.nodeStream(body) && is.function_((body as FormData).getBoundary);
   }
 
   if (headers && 'content-length' in headers) {

--- a/src/util/get-body-size.ts
+++ b/src/util/get-body-size.ts
@@ -4,7 +4,7 @@ import is from '@sindresorhus/is';
 
 export function getBodySize(
   body: HttpBody | undefined,
-  headers: { [name: string]: string } | undefined,
+  headers: { [name: string]: string } = {},
 ): number | undefined {
   function isFormData(body: unknown): body is FormData {
     return is.nodeStream(body) && is.function_((body as FormData).getBoundary);
@@ -29,8 +29,15 @@ export function getBodySize(
   if (is.buffer(body)) {
     return body.length;
   }
-  if (isFormData(body)) {
-    return body.getLengthSync();
+
+  try {
+    // `getLengthSync` will throw if body has a stream:
+    // https://github.com/form-data/form-data#integer-getlengthsync
+    if (isFormData(body)) {
+      return body.getLengthSync();
+    }
+  } catch {
+    return undefined;
   }
 
   return undefined;

--- a/src/util/get-body-size.ts
+++ b/src/util/get-body-size.ts
@@ -1,0 +1,43 @@
+import type { Readable } from 'node:stream';
+import { HttpBody } from '../types';
+
+export async function getBodySize(
+  body: HttpBody | undefined,
+  headers: { [name: string]: string } | undefined,
+): Promise<number | undefined> {
+  const { default: is } = await import('@sindresorhus/is');
+
+  function isFormData(body: unknown): body is FormData {
+    return is.nodeStream(body) && is.function((body as FormData).getBoundary);
+  }
+
+  if (headers && 'content-length' in headers) {
+    return Number(headers['content-length']);
+  }
+
+  if (!body) {
+    return 0;
+  }
+
+  if (is.string(body)) {
+    return Buffer.byteLength(body);
+  }
+
+  if (is.urlSearchParams(body)) {
+    return Buffer.byteLength(body.toString());
+  }
+
+  if (is.buffer(body)) {
+    return body.length;
+  }
+  if (isFormData(body)) {
+    return body.toString().length;
+  }
+
+  return undefined;
+}
+
+type FormData = {
+  getBoundary: () => string;
+  getLength: (callback: (error: Error | null, length: number) => void) => void;
+} & Readable;

--- a/test/body-size.test.ts
+++ b/test/body-size.test.ts
@@ -1,0 +1,40 @@
+import FormData from 'form-data';
+import assert from 'assert';
+import path from 'path';
+import fs from './helper/fs';
+import { isNodeJS } from './helper/env';
+import { getBodySize } from '../src/util/get-body-size';
+
+describe('HTTP body size', () => {
+  if (isNodeJS()) {
+    it('form data body with file stream should return undefined', () => {
+      const zip = fs.createReadStream(
+        path.join(__dirname, 'data/MyPackage.zip'),
+      );
+      const form = new FormData();
+
+      form.append('file', zip, {
+        contentType: 'application/zip',
+      });
+
+      assert.equal(getBodySize(form), undefined);
+    });
+
+    it('file stream body should return undefined', () => {
+      const zip = fs.createReadStream(
+        path.join(__dirname, 'data/MyPackage.zip'),
+      );
+
+      assert.equal(getBodySize(zip), undefined);
+    });
+  }
+
+  it('should return "content-length" header when set', () => {
+    assert.equal(
+      getBodySize('test', {
+        'content-length': '256',
+      }),
+      256,
+    );
+  });
+});


### PR DESCRIPTION
feat: automatically set `content-length` header on REST/SOAP requests.

We've been getting a few reports that some internal envs started to enforce this header on requests, adding support in jsforce as a safety measure.

## Tests
while working on this I found the HTTP module doesn't any UT, there's some coverage for session refresh in different e2e tests but we today we don't have an easy way to test this behavior, I'll add some tests for this when working on
[W-14580746: [jsforce]: increase HTTP module test coverage]
(https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001fXgwbYAC/view)

## QA

not really an easy way to QA this without getting one of those internal envs, but you can try running tests with this env var:
`JSFORCE_LOG_LEVEL=DEBUG` to get the body size added in each request (I tried adding to mock the logger to grab the value and compare it in e2e tests but couldn't get it to work on browser/tests (you can't use jest specific stuff).

@W-14177773@