### PR TITLE
test: add tests for HTTP API module

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,13 +37,13 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'webpack'],
 
     // list of files / patterns to load in the browser
-    files: ['dist/jsforce.js', 'test/**/*.test.ts'],
+    files: ['dist/jsforce.js', 'test/**/!(*http-api).test.ts'],
 
     // list of files / patterns to exclude
-    exclude: ['test/http-api.test.ts'],
+    exclude: [],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
     files: ['dist/jsforce.js', 'test/**/*.test.ts'],
 
     // list of files / patterns to exclude
-    exclude: [],
+    exclude: ['test/http-api.test.ts'],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.0.0-next.0",
+  "version": "3.0.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.1",
@@ -69,6 +69,7 @@
         "karma-jasmine-html-reporter": "^2.0.0",
         "karma-sourcemap-loader": "^0.4.0",
         "karma-webpack": "^5.0.0",
+        "nock": "^13.4.0",
         "path-browserify": "^1.0.1",
         "power-assert": "^1.6.1",
         "prettier": "^2.2.1",
@@ -12957,6 +12958,43 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/nock": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.4.0.tgz",
+      "integrity": "sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -13834,6 +13872,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proper-lockfile": {

--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "karma-jasmine-html-reporter": "^2.0.0",
     "karma-sourcemap-loader": "^0.4.0",
     "karma-webpack": "^5.0.0",
+    "nock": "^13.4.0",
     "path-browserify": "^1.0.1",
     "power-assert": "^1.6.1",
     "prettier": "^2.2.1",

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -75,11 +75,6 @@ await $`sf force data bulk upsert --file ${bigTableCsv} --sobject BigTable__c --
 await $`sf force data bulk upsert --file ${bigTableCsv} --sobject BigTable__c --external-id Id --target-org jsforce-test-org`;
 await $`sf force data bulk upsert --file ${bigTableCsv} --sobject BigTable__c --external-id Id --target-org jsforce-test-org`;
 
-const pushTopicValues =
-  "Name='JSforceTestAccountUpdates' Query='SELECT Id, Name FROM Account' ApiVersion='54.0' NotifyForFields=Referenced NotifyForOperationCreate=true NotifyForOperationUpdate=true NotifyForOperationDelete=false NotifyForOperationUndelete=false";
-
-await $`sf data create record --sobject PushTopic --values ${pushTopicValues} --target-org jsforce-test-org`;
-
 if (!process.env.CI) {
   console.log(
     `Run tests using this scratch org by appending SF_LOGIN_URL=${orgDisplayUserRes.result.instanceUrl} SF_USERNAME=${orgDisplayUserRes.result.username} SF_PASSWORD=${orgDisplayUserRes.result.password}`,

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -288,6 +288,11 @@ export class HttpApi<S extends Schema> extends EventEmitter {
    */
   parseError(body: any) {
     const errors = body;
+
+    // XML response
+    if (errors['Errors']) {
+      return errors['Errors']['Error'];
+    }
     return Array.isArray(errors) ? errors[0] : errors;
   }
 

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -316,6 +316,18 @@ export class HttpApi<S extends Schema> extends EventEmitter {
             errorCode: `ERROR_HTTP_${response.statusCode}`,
             message: response.body,
           };
+
+    if (response.headers['content-type'] === 'text/html') {
+      this._logger.debug(`html response.body: ${response.body}`);
+      return new HttpApiError(
+        `HTTP response contains html content.
+Check that the org exists and can be reached.
+See error.content for the full html response.`,
+        error.errorCode,
+        error.message,
+      );
+    }
+
     return new HttpApiError(error.message, error.errorCode);
   }
 }

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -290,9 +290,10 @@ export class HttpApi<S extends Schema> extends EventEmitter {
     const errors = body;
 
     // XML response
-    if (errors['Errors']) {
-      return errors['Errors']['Error'];
+    if (errors.Errors) {
+      return errors.Errors.Error;
     }
+
     return Array.isArray(errors) ? errors[0] : errors;
   }
 

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -282,6 +282,8 @@ it('should call bulk api from invalid session conn with refresh fn, and return r
     },
   });
 
+  conn2.bulk2.pollTimeout = 90000;
+
   const deleteRecords = bulkInsert.successfulResults.map((r) => ({
     Id: r.sf__Id,
   }));
@@ -302,6 +304,9 @@ it('should call bulk api from invalid session conn without refresh fn, and raise
     logLevel: config.logLevel,
     proxyUrl: config.proxyUrl,
   });
+
+  conn3.bulk2.pollTimeout = 90000;
+
   const records = [{ Name: 'Impossible Bulk Account #1' }];
   try {
     await conn3.bulk2.loadAndWaitForResults({

--- a/test/helper/webauth/index.ts
+++ b/test/helper/webauth/index.ts
@@ -48,7 +48,7 @@ export default async function authorize(
   password: string,
 ) {
   const browser = await puppeteer.launch({
-    headless: true,
+    headless: 'new',
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   });
   let ret;

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -3,11 +3,12 @@ import { SOAP } from '../src/soap';
 import { Connection } from '../src/connection';
 import { HttpRequest, HttpResponse } from '../src/types';
 import assert from 'assert';
+import xml2js from 'xml2js';
 import nock = require('nock');
 
-describe('HTTP API', () => {
-  const loginUrl = 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com';
+const loginUrl = 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com';
 
+describe('HTTP API', () => {
   const accessToken = '1234';
 
   const conn = new Connection({
@@ -15,43 +16,107 @@ describe('HTTP API', () => {
     loginUrl,
   });
 
-  const httpApi = new HttpApi(conn, {});
+  describe('headers', () => {
+    it('sets `Authorization` header', async () => {
+      let testPassed = false;
 
-  it('sets authorization header', async () => {
-    let testPassed = false;
+      const httpApi = new HttpApi(conn, {});
 
-    httpApi.on('request', (req: HttpRequest) => {
-      assert.ok(req?.headers?.['Authorization'] === `Bearer ${accessToken}`);
-      testPassed = true;
+      httpApi.on('request', (req: HttpRequest) => {
+        assert.ok(req?.headers?.['Authorization'] === `Bearer ${accessToken}`);
+        testPassed = true;
+      });
+
+      nock(loginUrl).get('/services/data/v59.0').reply(200, {});
+
+      await httpApi.request<HttpResponse>({
+        method: 'GET',
+        url: `${loginUrl}/services/data/v59.0`,
+      });
+      assert.ok(testPassed);
     });
 
-    nock(loginUrl).get('/services/data/v59.0').reply(200, {});
+    it('sets `Call Options` header', async () => {
+      const conn = new Connection({
+        accessToken,
+        loginUrl,
+        callOptions: {
+          client: 'caseSensitiveToken',
+          defaultNamespace: 'battle',
+        },
+      });
 
-    await httpApi.request<HttpResponse>({
-      method: 'GET',
-      url: `${loginUrl}/services/data/v59.0`,
+      const httpApi = new HttpApi(conn, {});
+
+      let testPassed = false;
+
+      httpApi.on('request', (req: HttpRequest) => {
+        assert.equal(
+          req?.headers?.['Sforce-Call-Options'],
+          'client=caseSensitiveToken, defaultNamespace=battle',
+        );
+        testPassed = true;
+      });
+
+      nock(loginUrl).get('/services/data/v59.0').reply(200, {});
+
+      await httpApi.request<HttpResponse>({
+        method: 'GET',
+        url: `${loginUrl}/services/data/v59.0`,
+      });
+      assert.ok(testPassed);
     });
-    assert.ok(testPassed);
-  });
 
-  it('sets content-length header', async () => {
-    let testPassed = false;
+    it('sets `Content-Length` header', async () => {
+      let testPassed = false;
 
-    httpApi.on('request', (req: HttpRequest) => {
-      assert.equal(req?.headers?.['content-length'], '19');
-      testPassed = true;
+      const httpApi = new HttpApi(conn, {});
+
+      httpApi.on('request', (req: HttpRequest) => {
+        assert.equal(req?.headers?.['content-length'], '19');
+        testPassed = true;
+      });
+
+      nock(loginUrl)
+        .post('/services/data/v59.0/sobjects/Account')
+        .reply(200, {});
+
+      await httpApi.request<HttpResponse>({
+        method: 'POST',
+        body: JSON.stringify({
+          Name: 'John Doe',
+        }),
+        url: `${loginUrl}/services/data/v59.0/sobjects/Account`,
+      });
+      assert.ok(testPassed);
     });
 
-    nock(loginUrl).post('/services/data/v59.0/sobjects/Account').reply(200, {});
+    it('does not set `Content-Length` when `Transfer-Encoding` header is set', async () => {
+      let testPassed = false;
 
-    await httpApi.request<HttpResponse>({
-      method: 'POST',
-      body: JSON.stringify({
-        Name: 'John Doe',
-      }),
-      url: `${loginUrl}/services/data/v59.0/sobjects/Account`,
+      const httpApi = new HttpApi(conn, {});
+
+      httpApi.on('request', (req: HttpRequest) => {
+        assert.equal(req?.headers?.['content-length'], undefined);
+        testPassed = true;
+      });
+
+      nock(loginUrl)
+        .post('/services/data/v59.0/sobjects/Account')
+        .reply(200, {});
+
+      await httpApi.request<HttpResponse>({
+        method: 'POST',
+        headers: {
+          'transfer-encoding': 'chunked',
+        },
+        body: JSON.stringify({
+          Name: 'John Doe',
+        }),
+        url: `${loginUrl}/services/data/v59.0/sobjects/Account`,
+      });
+      assert.ok(testPassed);
     });
-    assert.ok(testPassed);
   });
 
   describe('session refresh', () => {
@@ -71,11 +136,11 @@ describe('HTTP API', () => {
 
       httpApi.on('request', (req: HttpRequest) => {
         if (firstRoundTrip) {
-          // bearer token set in the connection.
+          // access token set in the connection.
           assert.equal(req?.headers?.['Authorization'], `Bearer invalid_token`);
           firstRoundTrip = false;
         } else {
-          // bearer token set in the connection's refresh function.
+          // access token set in the connection's refresh function.
           assert.equal(
             req?.headers?.['Authorization'],
             `Bearer refreshed_token`,
@@ -96,8 +161,190 @@ describe('HTTP API', () => {
       });
       assert.ok(testPassed);
     });
+  });
 
-    it('SOAP: handle `content-length` header after session refresh', async () => {
+  describe('error handling', () => {
+    it('JSON response', async () => {
+      const conn = new Connection({
+        accessToken,
+        loginUrl,
+      });
+
+      const httpApi = new HttpApi(conn, {});
+
+      const missingRequiredFieldErr = [
+        {
+          message: 'Required fields are missing: [Name]',
+          errorCode: 'REQUIRED_FIELD_MISSING',
+          fields: ['Name'],
+        },
+      ];
+
+      nock(loginUrl)
+        .post('/services/data/v59.0')
+        .reply(400, JSON.stringify(missingRequiredFieldErr), {
+          'content-type': 'application/json',
+        });
+
+      assert.rejects(
+        async () => {
+          await httpApi.request<HttpResponse>({
+            method: 'POST',
+            body: JSON.stringify({
+              Description: 'Accountant',
+            }),
+            url: `${loginUrl}/services/data/v59.0`,
+          });
+        },
+        {
+          errorCode: missingRequiredFieldErr[0].errorCode,
+          message: missingRequiredFieldErr[0].message,
+        },
+      );
+    });
+
+    it('XML response', async () => {
+      const conn = new Connection({
+        accessToken,
+        loginUrl,
+      });
+
+      const httpApi = new HttpApi(conn, {});
+
+      const xmlErr = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Errors>
+	<Error>
+		<errorCode>NOT_FOUND</errorCode>
+		<message>The requested resource does not exist</message>
+	</Error>
+</Errors>`;
+
+      nock(loginUrl)
+        .get('/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA')
+        .reply(400, xmlErr, {
+          'content-type': 'application/xml',
+        });
+
+      assert.rejects(
+        async () => {
+          await httpApi.request<HttpResponse>({
+            method: 'GET',
+            url: `${loginUrl}/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA`,
+          });
+        },
+        {
+          errorCode: 'NOT_FOUND',
+          message: 'The requested resource does not exist',
+        },
+      );
+    });
+  });
+});
+
+describe('SOAP API', () => {
+  async function parseXML(str: string) {
+    return xml2js.parseStringPromise(str, { explicitArray: false });
+  }
+
+  describe('headers', () => {
+    it('sets required HTTP headers', async () => {
+      let testPassed = false;
+
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'access_token',
+      });
+
+      const soapApi = new SOAP(conn, {
+        xmlns: 'urn:partner.soap.sforce.com',
+        endpointUrl: `${loginUrl}/services/Soap/u/59`,
+      });
+
+      soapApi.on('request', async (req: HttpRequest) => {
+        assert.equal(req?.headers?.['Content-Type'], 'text/xml');
+        assert.equal(req?.headers?.['SOAPAction'], '""');
+        testPassed = true;
+      });
+
+      nock(loginUrl).post('/services/Soap/u/59').reply(200);
+
+      await soapApi.invoke('describeMetadata', {
+        asOfVersion: '59.0',
+      });
+
+      assert.ok(testPassed);
+    });
+
+    it('sets SOAP "Session" header', async () => {
+      let testPassed = false;
+
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'access_token',
+      });
+
+      const soapApi = new SOAP(conn, {
+        xmlns: 'urn:partner.soap.sforce.com',
+        endpointUrl: `${loginUrl}/services/Soap/u/59`,
+      });
+
+      soapApi.on('request', async (req: HttpRequest) => {
+        const parsedBody = await parseXML(req.body as string);
+        assert.deepEqual(
+          parsedBody['soapenv:Envelope']['soapenv:Header']['SessionHeader'],
+          { sessionId: conn.accessToken },
+        );
+        testPassed = true;
+      });
+
+      nock(loginUrl).post('/services/Soap/u/59').reply(200);
+
+      await soapApi.invoke('describeMetadata', {
+        asOfVersion: '59.0',
+      });
+
+      assert.ok(testPassed);
+    });
+
+    it('sets SOAP "Call options" header', async () => {
+      let testPassed = false;
+
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'access_token',
+        callOptions: {
+          client: 'caseSensitiveToken',
+          defaultNamespace: 'battle',
+        },
+      });
+
+      const soapApi = new SOAP(conn, {
+        xmlns: 'urn:partner.soap.sforce.com',
+        endpointUrl: `${loginUrl}/services/Soap/u/59`,
+      });
+
+      soapApi.on('request', async (req: HttpRequest) => {
+        const parsedBody = await parseXML(req.body as string);
+        assert.deepEqual(
+          parsedBody['soapenv:Envelope']['soapenv:Header']['CallOptions'],
+          conn._callOptions,
+        );
+        testPassed = true;
+      });
+
+      nock(loginUrl).post('/services/Soap/u/59').reply(200);
+
+      await soapApi.invoke('describeMetadata', {
+        asOfVersion: '59.0',
+      });
+
+      assert.ok(testPassed);
+    });
+  });
+
+  describe('session refresh', () => {
+    it('handle `Content-Length` header after session refresh', async () => {
       const conn = new Connection({
         loginUrl,
         accessToken: 'invalid_token',
@@ -114,8 +361,9 @@ describe('HTTP API', () => {
       let testPassed = false;
       let firstRoundTrip = true;
 
-      /* SOAP requests include the access token in the body,
-       * the first req will have `content-length` calculated with the invalid AT
+      /*
+       * SOAP requests include the access token in the body.
+       * The first req will have `content-length` calculated with the invalid AT,
        * the second one should have it re-calculated with the refreshed AT.
        */
       soapApi.on('request', (req: HttpRequest) => {
@@ -141,41 +389,42 @@ describe('HTTP API', () => {
     });
   });
 
-  it('handles bad responses', async () => {
+  it('parses errors in XML responses', async () => {
     const conn = new Connection({
-      accessToken,
       loginUrl,
+      accessToken: 'access_token',
     });
 
-    const httpApi = new HttpApi(conn, {});
+    const soapApi = new SOAP(conn, {
+      xmlns: 'urn:partner.soap.sforce.com',
+      endpointUrl: `${loginUrl}/services/Soap/u/59`,
+    });
 
-    const missingRequiredFieldErr = [
-      {
-        message: 'Required fields are missing: [Name]',
-        errorCode: 'REQUIRED_FIELD_MISSING',
-        fields: ['Name'],
-      },
-    ];
-
-    nock(loginUrl)
-      .post('/services/data/v59.0')
-      .reply(400, JSON.stringify(missingRequiredFieldErr), {
-        'content-type': 'application/json',
-      });
+    const xmlErr = `
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="http://soap.sforce.com/2006/04/metadata">
+    <soapenv:Body>
+        <soapenv:Fault>
+            <faultcode>sf:INVALID_SESSION_ID</faultcode>
+            <faultstring>INVALID_SESSION_ID: Invalid Session ID found in SessionHeader: Illegal Session</faultstring>
+        </soapenv:Fault>
+    </soapenv:Body>
+</soapenv:Envelope>
+`;
+    nock(loginUrl).post('/services/Soap/u/59').reply(400, xmlErr, {
+      'content-type': 'application/xml',
+    });
 
     assert.rejects(
       async () => {
-        await httpApi.request<HttpResponse>({
-          method: 'POST',
-          body: JSON.stringify({
-            Description: 'Accountant',
-          }),
-          url: `${loginUrl}/services/data/v59.0`,
+        await soapApi.invoke('create', {
+          Account: 'test',
         });
       },
       {
-        errorCode: missingRequiredFieldErr[0].errorCode,
-        message: missingRequiredFieldErr[0].message,
+        errorCode: 'sf:INVALID_SESSION_ID',
+        message:
+          'INVALID_SESSION_ID: Invalid Session ID found in SessionHeader: Illegal Session',
       },
     );
   });

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -239,6 +239,49 @@ describe('HTTP API', () => {
         },
       );
     });
+
+    it('HTML response', async () => {
+      const conn = new Connection({
+        accessToken,
+        loginUrl,
+      });
+
+      const httpApi = new HttpApi(conn, {});
+
+      const htmlErr = `
+<!DOCTYPE HTML>
+<html lang=en-US>
+<head>
+<meta charset=UTF-8>
+<title>Error Page</title>
+</head>
+<body>
+    <p>Error</p>
+</body>
+</html>
+`;
+
+      nock(loginUrl)
+        .get('/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA')
+        .reply(420, htmlErr, {
+          'content-type': 'text/html',
+        });
+
+      assert.rejects(
+        async () => {
+          await httpApi.request<HttpResponse>({
+            method: 'GET',
+            url: `${loginUrl}/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA`,
+          });
+        },
+        {
+          errorCode: 'ERROR_HTTP_420',
+          message: `HTTP response contains html content.
+Check that the org exists and can be reached.
+See error.content for the full html response.`,
+        },
+      );
+    });
   });
 });
 

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -29,7 +29,7 @@ describe('HTTP API', () => {
 
       nock(loginUrl).get('/services/data/v59.0').reply(200, {});
 
-      await httpApi.request<HttpResponse>({
+      await httpApi.request({
         method: 'GET',
         url: `${loginUrl}/services/data/v59.0`,
       });
@@ -60,7 +60,7 @@ describe('HTTP API', () => {
 
       nock(loginUrl).get('/services/data/v59.0').reply(200, {});
 
-      await httpApi.request<HttpResponse>({
+      await httpApi.request({
         method: 'GET',
         url: `${loginUrl}/services/data/v59.0`,
       });
@@ -81,7 +81,7 @@ describe('HTTP API', () => {
         .post('/services/data/v59.0/sobjects/Account')
         .reply(200, {});
 
-      await httpApi.request<HttpResponse>({
+      await httpApi.request({
         method: 'POST',
         body: JSON.stringify({
           Name: 'John Doe',
@@ -105,7 +105,7 @@ describe('HTTP API', () => {
         .post('/services/data/v59.0/sobjects/Account')
         .reply(200, {});
 
-      await httpApi.request<HttpResponse>({
+      await httpApi.request({
         method: 'POST',
         headers: {
           'transfer-encoding': 'chunked',
@@ -155,7 +155,7 @@ describe('HTTP API', () => {
         .get('/services/data/v59.0')
         .reply(200);
 
-      await httpApi.request<HttpResponse>({
+      await httpApi.request({
         method: 'GET',
         url: `${loginUrl}/services/data/v59.0`,
       });
@@ -188,7 +188,7 @@ describe('HTTP API', () => {
 
       assert.rejects(
         async () => {
-          await httpApi.request<HttpResponse>({
+          await httpApi.request({
             method: 'POST',
             body: JSON.stringify({
               Description: 'Accountant',
@@ -228,7 +228,7 @@ describe('HTTP API', () => {
 
       assert.rejects(
         async () => {
-          await httpApi.request<HttpResponse>({
+          await httpApi.request({
             method: 'GET',
             url: `${loginUrl}/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA`,
           });
@@ -269,7 +269,7 @@ describe('HTTP API', () => {
 
       assert.rejects(
         async () => {
-          await httpApi.request<HttpResponse>({
+          await httpApi.request({
             method: 'GET',
             url: `${loginUrl}/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA`,
           });
@@ -281,6 +281,34 @@ Check that the org exists and can be reached.
 See error.content for the full html response.`,
         },
       );
+    });
+
+    it('returns `noContentResponse` on 204', async () => {
+      const conn = new Connection({
+        accessToken,
+        loginUrl,
+      });
+
+      const noContentResponse = {
+        id: 'a008N0000032UmoQAA ',
+        success: true,
+        errors: [],
+      };
+
+      const httpApi = new HttpApi(conn, {
+        noContentResponse,
+      });
+
+      nock(loginUrl)
+        .delete('/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA')
+        .reply(204);
+
+      const body = await httpApi.request({
+        method: 'DELETE',
+        url: `${loginUrl}/services/data/v59.0/sobjects/Broker__c/a008N0000032UmoQAA`,
+      });
+
+      assert.deepEqual(body, noContentResponse);
     });
   });
 });

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -1,0 +1,182 @@
+import { HttpApi } from '../src/http-api';
+import { SOAP } from '../src/soap';
+import { Connection } from '../src/connection';
+import { HttpRequest, HttpResponse } from '../src/types';
+import assert from 'assert';
+import nock = require('nock');
+
+describe('HTTP API', () => {
+  const loginUrl = 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com';
+
+  const accessToken = '1234';
+
+  const conn = new Connection({
+    accessToken,
+    loginUrl,
+  });
+
+  const httpApi = new HttpApi(conn, {});
+
+  it('sets authorization header', async () => {
+    let testPassed = false;
+
+    httpApi.on('request', (req: HttpRequest) => {
+      assert.ok(req?.headers?.['Authorization'] === `Bearer ${accessToken}`);
+      testPassed = true;
+    });
+
+    nock(loginUrl).get('/services/data/v59.0').reply(200, {});
+
+    await httpApi.request<HttpResponse>({
+      method: 'GET',
+      url: `${loginUrl}/services/data/v59.0`,
+    });
+    assert.ok(testPassed);
+  });
+
+  it('sets content-length header', async () => {
+    let testPassed = false;
+
+    httpApi.on('request', (req: HttpRequest) => {
+      assert.equal(req?.headers?.['content-length'], '19');
+      testPassed = true;
+    });
+
+    nock(loginUrl).post('/services/data/v59.0/sobjects/Account').reply(200, {});
+
+    await httpApi.request<HttpResponse>({
+      method: 'POST',
+      body: JSON.stringify({
+        Name: 'John Doe',
+      }),
+      url: `${loginUrl}/services/data/v59.0/sobjects/Account`,
+    });
+    assert.ok(testPassed);
+  });
+
+  describe('session refresh', () => {
+    it('refreshes expired session', async () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'invalid_token',
+        refreshFn: (_c, callback) => {
+          setTimeout(() => callback(null, 'refreshed_token' ?? undefined), 200);
+        },
+      });
+
+      const httpApi = new HttpApi(conn, {});
+
+      let testPassed = false;
+      let firstRoundTrip = true;
+
+      httpApi.on('request', (req: HttpRequest) => {
+        if (firstRoundTrip) {
+          // bearer token set in the connection.
+          assert.equal(req?.headers?.['Authorization'], `Bearer invalid_token`);
+          firstRoundTrip = false;
+        } else {
+          // bearer token set in the connection's refresh function.
+          assert.equal(
+            req?.headers?.['Authorization'],
+            `Bearer refreshed_token`,
+          );
+          testPassed = true;
+        }
+      });
+
+      nock(loginUrl)
+        .get('/services/data/v59.0')
+        .reply(401)
+        .get('/services/data/v59.0')
+        .reply(200);
+
+      await httpApi.request<HttpResponse>({
+        method: 'GET',
+        url: `${loginUrl}/services/data/v59.0`,
+      });
+      assert.ok(testPassed);
+    });
+
+    it('SOAP: handle `content-length` header after session refresh', async () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'invalid_token',
+        refreshFn: (_c, callback) => {
+          setTimeout(() => callback(null, 'refreshed_token' ?? undefined), 200);
+        },
+      });
+
+      const soapApi = new SOAP(conn, {
+        xmlns: 'urn:partner.soap.sforce.com',
+        endpointUrl: `${loginUrl}/services/Soap/u/59`,
+      });
+
+      let testPassed = false;
+      let firstRoundTrip = true;
+
+      /* SOAP requests include the access token in the body,
+       * the first req will have `content-length` calculated with the invalid AT
+       * the second one should have it re-calculated with the refreshed AT.
+       */
+      soapApi.on('request', (req: HttpRequest) => {
+        if (firstRoundTrip) {
+          assert.equal(req?.headers?.['content-length'], '473');
+          firstRoundTrip = false;
+        } else {
+          assert.equal(req?.headers?.['content-length'], '475');
+          testPassed = true;
+        }
+      });
+
+      nock(loginUrl)
+        .post('/services/Soap/u/59')
+        .reply(500, '<faultcode>test:INVALID_SESSION_ID</faultcode>')
+        .post('/services/Soap/u/59')
+        .reply(200);
+
+      await soapApi.invoke('create', {
+        Account: 'test',
+      });
+      assert.ok(testPassed);
+    });
+  });
+
+  it('handles bad responses', async () => {
+    const conn = new Connection({
+      accessToken,
+      loginUrl,
+    });
+
+    const httpApi = new HttpApi(conn, {});
+
+    const missingRequiredFieldErr = [
+      {
+        message: 'Required fields are missing: [Name]',
+        errorCode: 'REQUIRED_FIELD_MISSING',
+        fields: ['Name'],
+      },
+    ];
+
+    nock(loginUrl)
+      .post('/services/data/v59.0')
+      .reply(400, JSON.stringify(missingRequiredFieldErr), {
+        'content-type': 'application/json',
+      });
+
+    assert.rejects(
+      async () => {
+        await httpApi.request<HttpResponse>({
+          method: 'POST',
+          body: JSON.stringify({
+            Description: 'Accountant',
+          }),
+          url: `${loginUrl}/services/data/v59.0`,
+        });
+      },
+      {
+        errorCode: missingRequiredFieldErr[0].errorCode,
+        message: missingRequiredFieldErr[0].message,
+      },
+    );
+  });
+});

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -1,7 +1,7 @@
 import { HttpApi } from '../src/http-api';
 import { SOAP } from '../src/soap';
 import { Connection } from '../src/connection';
-import { HttpRequest, HttpResponse } from '../src/types';
+import { HttpRequest } from '../src/types';
 import assert from 'assert';
 import xml2js from 'xml2js';
 import nock = require('nock');

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -25,14 +25,28 @@ if (isNodeJS()) {
    */
   it('should subscribe to topic, create account, and receive event of account has been created', async () => {
     type Account = { Id: string; Name: string };
+
+    const id = Date.now();
+
+    const accountName = `My New Account #${id}`;
+
+    const pushTopicName = `Topic-${id}`;
+
+    await conn.sobject('PushTopic').create({
+      Name: pushTopicName,
+      Query: `SELECT Id, Name FROM Account WHERE Name='${accountName}'`,
+      ApiVersion: '54.0',
+      NotifyForFields: 'Referenced',
+      NotifyForOperationCreate: true,
+      NotifyForOperationUpdate: true,
+      NotifyForOperationDelete: false,
+      NotifyForOperationUndelete: false,
+    });
+
     let subscr: Subscription | undefined;
     const msgArrived = new Promise<StreamingMessage<Account>>((resolve) => {
-      subscr = conn.streaming
-        .topic<Account>('JSforceTestAccountUpdates')
-        .subscribe(resolve);
+      subscr = conn.streaming.topic<Account>(pushTopicName).subscribe(resolve);
     });
-    await delay(10000);
-    const accountName = `My New Account #${Date.now()}`;
 
     await conn.sobject('Account').create({ Name: accountName });
 
@@ -55,6 +69,8 @@ if (isNodeJS()) {
     if (subscr) {
       subscr.cancel();
     }
+
+    await conn.sobject('PushTopic').findOne({ Name: pushTopicName }).delete();
   });
 
   /**


### PR DESCRIPTION
Adds unit tests for the HTTP API module (including SOAP wrapper).

UTs cover HTTP/SOAP headers, session refresh, parsing error in responses.

@W-14580746@