### PR TITLE
feat: retry on network errors

### DIFF
--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -15,6 +15,11 @@ export function createHttpRequestHandlerStreams(
   const output = new PassThrough();
   const duplex = concatStreamsAsDuplex(input, output);
 
+  // TODO: handle body as readable stream.
+  // `HttpRequest` accepts a readable stream but here we just check
+  // for a FormData instance or a buffer/string.
+  //
+  // then use https://github.com/mcollina/cloneable-readable in retry logic to clone/destroy body streams.
   if (typeof reqBody !== 'undefined') {
     setTimeout(() => {
       if (reqBody instanceof FormData) {

--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -15,11 +15,6 @@ export function createHttpRequestHandlerStreams(
   const output = new PassThrough();
   const duplex = concatStreamsAsDuplex(input, output);
 
-  // TODO: handle body as readable stream.
-  // `HttpRequest` accepts a readable stream but here we just check
-  // for a FormData instance or a buffer/string.
-  //
-  // then use https://github.com/mcollina/cloneable-readable in retry logic to clone/destroy body streams.
   if (typeof reqBody !== 'undefined') {
     setTimeout(() => {
       if (reqBody instanceof FormData) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -11,6 +11,7 @@ import {
 } from './request-helper';
 import { HttpRequest, HttpRequestOptions } from './types';
 import { getLogger } from './util/logger';
+import is from '@sindresorhus/is';
 
 /**
  *
@@ -95,6 +96,13 @@ async function startFetchRequest(
         if (retryCount === maxRetry) return false;
 
         if (!retryOpts?.methods?.includes(request.method)) return false;
+
+        if (is.nodeStream(body) && Readable.isDisturbed(body)) {
+          logger.debug(
+            'Body of type stream was read, unable to retry request.',
+          );
+          return false;
+        }
 
         if (
           'code' in error &&

--- a/src/request.ts
+++ b/src/request.ts
@@ -68,7 +68,7 @@ async function startFetchRequest(
   ): Promise<Response> => {
     const fetchOpts: RequestInit = {
       ...rrequest,
-      ...(input && /^(post|put|patch)$/i.test(request.method)
+      ...(request.body && input && /^(post|put|patch)$/i.test(request.method)
         ? { body: input }
         : {}),
       redirect: 'manual',

--- a/src/request.ts
+++ b/src/request.ts
@@ -68,7 +68,7 @@ async function startFetchRequest(
   ): Promise<Response> => {
     const fetchOpts: RequestInit = {
       ...rrequest,
-      ...(request.body && input && /^(post|put|patch)$/i.test(request.method)
+      ...(input && /^(post|put|patch)$/i.test(request.method)
         ? { body: input }
         : {}),
       redirect: 'manual',

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -26,7 +26,8 @@ export type HttpMethods =
   | 'PUT'
   | 'PATCH'
   | 'DELETE'
-  | 'OPTIONS';
+  | 'OPTIONS'
+  | 'HEAD';
 
 export type HttpRequest = {
   url: string;
@@ -36,6 +37,11 @@ export type HttpRequest = {
 };
 
 export type HttpRequestOptions = {
+  retry?: {
+    maxRetries?: number;
+    errorCodes?: string[];
+    methods?: HttpMethods[];
+  };
   httpProxy?: string;
   timeout?: number;
   followRedirect?: boolean | ((redirectUrl: string) => HttpRequest | null);


### PR DESCRIPTION
This PR adds a simple retry mechanism for the node-fetch wrapper.

Implements some options of undici's (node's fetch) retry handler:
https://undici.nodejs.org/#/docs/api/RetryAgent

jsforce v4 will target native fetch on node/browser so the retry API will stay the same for node consumers.

### Caveats:
1. this code will very likely get removed in jsforce v4 (node's fetch handles retries)
2. the retry mechanism is at the low-level request helper and relies on node-fetch actually throwing, 


### How is the node-fetch wrapper used?

Connection class is instantiated, it sets the HTTP transport:
https://github.com/jsforce/jsforce/blob/3a88038617494cd2c877f152363218f17939c400/src/connection.ts#L346-L350

then `HttpApi.httpRequest` gets the `request` wrapper here:
https://github.com/jsforce/jsforce/blob/3a88038617494cd2c877f152363218f17939c400/src/transport.ts#L50

the `request` func is part of the public API, will be doc'd here:
https://github.com/jsforce/jsforce-website/pull/10 (needs updates) 

@W-14990080@