### PR TITLE
feat: retry on statusCodes

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -45,6 +45,7 @@ async function startFetchRequest(
   let retryCount = 0;
 
   const retryOpts: Required<HttpRequestOptions['retry']> = {
+    statusCodes: options.retry?.statusCodes ?? [429, 500, 502, 503, 504],
     maxRetries: options.retry?.maxRetries ?? 5,
     errorCodes: options.retry?.errorCodes ?? [
       'ECONNRESET',
@@ -66,6 +67,37 @@ async function startFetchRequest(
     ],
   };
 
+  const shouldRetryRequest = (
+    maxRetry: number,
+    resOrErr: Response | Error | FetchError,
+  ): boolean => {
+    if (maxRetry === retryCount) return false;
+
+    if (!retryOpts.methods.includes(request.method)) return false;
+
+    if (resOrErr instanceof Response) {
+      return retryOpts.statusCodes.includes(resOrErr.status);
+    } else {
+      // only retry on operational errors
+      // https://github.com/node-fetch/node-fetch/blob/2.x/ERROR-HANDLING.md#error-handling-with-node-fetch
+      if (resOrErr.name != 'FetchError') return false;
+
+      if (is.nodeStream(body) && Readable.isDisturbed(body)) {
+        logger.debug('Body of type stream was read, unable to retry request.');
+        return false;
+      }
+
+      if (
+        'code' in resOrErr &&
+        resOrErr.code &&
+        retryOpts?.errorCodes?.includes(resOrErr.code)
+      )
+        return true;
+
+      return false;
+    }
+  };
+
   const fetchWithRetries = async (
     maxRetry = retryOpts?.maxRetries,
   ): Promise<Response> => {
@@ -80,7 +112,19 @@ async function startFetchRequest(
     };
 
     try {
-      return await fetch(url, fetchOpts);
+      const res = await fetch(url, fetchOpts);
+      if (shouldRetryRequest(retryOpts.maxRetries, res)) {
+        logger.debug(`retrying for the ${retryCount + 1} time`);
+        logger.debug(`reason: statusCode match`);
+
+        // NOTE: this event is only used by tests and will be removed at any time.
+        // jsforce may switch to node's fetch which doesn't emit this event on retries.
+        emitter.emit('retry', retryCount);
+        retryCount++;
+
+        return await fetchWithRetries(maxRetry);
+      }
+      return res;
     } catch (err) {
       logger.debug(`Request failed`);
       const error = err as Error | FetchError;
@@ -90,31 +134,7 @@ async function startFetchRequest(
         throw error;
       }
 
-      const shouldRetry = (): boolean => {
-        // only retry on operational errors
-        if (error.name != 'FetchError') return false;
-        if (retryCount === maxRetry) return false;
-
-        if (!retryOpts?.methods?.includes(request.method)) return false;
-
-        if (is.nodeStream(body) && Readable.isDisturbed(body)) {
-          logger.debug(
-            'Body of type stream was read, unable to retry request.',
-          );
-          return false;
-        }
-
-        if (
-          'code' in error &&
-          error.code &&
-          retryOpts?.errorCodes?.includes(error.code)
-        )
-          return true;
-
-        return false;
-      };
-
-      if (shouldRetry()) {
+      if (shouldRetryRequest(retryOpts.maxRetries, error)) {
         logger.debug(`retrying for the ${retryCount + 1} time`);
         logger.debug(`Error: ${error}`);
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -41,7 +41,7 @@ export type HttpRequestOptions = {
     maxRetries?: number;
     errorCodes?: string[];
     methods?: HttpMethods[];
-    statusCodes?: number[]
+    statusCodes?: number[];
   };
   httpProxy?: string;
   timeout?: number;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -41,6 +41,7 @@ export type HttpRequestOptions = {
     maxRetries?: number;
     errorCodes?: string[];
     methods?: HttpMethods[];
+    statusCodes?: number[]
   };
   httpProxy?: string;
   timeout?: number;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -39,6 +39,8 @@ export type HttpRequest = {
 export type HttpRequestOptions = {
   retry?: {
     maxRetries?: number;
+    minTimeout?: number;
+    timeoutFactor?: number;
     errorCodes?: string[];
     methods?: HttpMethods[];
     statusCodes?: number[];


### PR DESCRIPTION
feat:
1. adds support for retry on status codes
2. adds support for minTimeout/timeoutFactor, this makes each retry to be delayed incrementally.

couldn't find a way to reliable UT n2 but this should mimic undici's behavior.

### How to QA n2

1) install sf >= 2.38.3 (that uses jsforce-node)
2) checkout this PR and build jsforce-node:
  a. `npm install` install 
  b. `npm run jsforce-node` build jsforce-node (you'll see pjson changes, don't revert them)
  c. link it into sfdx-core

3) compare time between retries:

turn off your wifi and try this with no plugins linked, you will see the retries happen instantly:
```
JSFORCE_LOG_LEVEL=DEBUG sf org list 
```

then run the same command on plugin-org, see each retry waits a bit longer:
```
JSFORCE_LOG_LEVEL=DEBUG ./bin/dev.js org list
```

@W-15451832@