### PR TITLE
fix(connection): undefined property access on batchDescribe

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1313,6 +1313,7 @@ Connection.prototype.doBatchDescribeRequest = function(types) {
   var url = [self._baseUrl(), "composite/batch"].join("/");
   var version = "v" + self.version;
   var batchRequests = [];
+  var logger = this._logger;
   types.forEach(function (type) {
     batchRequests.push({
       method: "GET",
@@ -1333,9 +1334,9 @@ Connection.prototype.doBatchDescribeRequest = function(types) {
         var subResp = response.results[i];
         if (Array.isArray(subResp.result)) {
           if (subResp.result[0].errorCode && subResp.result[0].message) {
-            this._logger.error(
+            logger.error(
               'Error: ' + subResp.result[0].errorCode + ' ' +  
-              subResp.result[0].message + ' - ' + typesToFetch[i]
+              subResp.result[0].message + ' - ' + types[i]
             );
           }
         } else {


### PR DESCRIPTION
If the response has errors, the `this._logger` property access fails.
Also, `typesToFetch` was incorrect, it doesn't exist, the parameter is `types`.

Fixed #1265