### PR TITLE
test: run e2e tests on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,7 +173,7 @@ jobs:
         run: npm install
 
       - name: Install sf CLI
-        run: npm install --global @salesforce/cli
+        run: npm install --global @salesforce/cli@nightly
 
       - name: Setup scratch org
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,9 +189,9 @@ jobs:
           SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
           SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
         run: |
-          $env:SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') `
-          $env:SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') `
-          $env:SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') `
+          $env:SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username')
+          $env:SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password')
+          $env:SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl')
           npm run test:node
 
       - name: Delete scratch org

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,61 +5,61 @@ on:
   workflow_dispatch:
 
 jobs:
-  # test-browser:
-  #   needs: lint-and-typecheck
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: browser-actions/setup-chrome@v1
-  #       with:
-  #         chrome-version: stable
-  #       id: setup-chrome
-  #     - uses: nanasess/setup-chromedriver@9cd356a368322c0154e5610c8d4a5aa5f3c146f5
-  #     - run: |
-  #         chromedriver --url-base=/wd/hub &
-  #         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: lts/*
-  #     - uses: google/wireit@setup-github-actions-caching/v1
-  #     - name: Install dependencies
-  #       run: npm install
-  #
-  #     - name: Install sf CLI
-  #       run: npm install --global @salesforce/cli
-  #
-  #     - name: Setup scratch org
-  #       env:
-  #         SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
-  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-  #         SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
-  #       run: |
-  #         npx zx scripts/org-setup.mjs
-  #
-  #     - name: Run browser tests with 3 attempts
-  #       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-  #       with:
-  #         max_attempts: 3
-  #         timeout_minutes: 30
-  #         retry_wait_seconds: 60
-  #         command: |
-  #           SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-  #           SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-  #           SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-  #           DISPLAY=:99 CHROME_BIN=$(which chrome) \
-  #           npm run test:browser-ci
-  #         new_command_on_retry: |
-  #           SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-  #           SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-  #           SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-  #           DISPLAY=:99 CHROME_BIN=$(which chrome) \
-  #           npm run test:browser-ci:retry
-  #         retry_on: error
-  #       env:
-  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-  #         SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
-  #         SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
-  #         SF_AJAX_PROXY_URL: ${{ vars.SF_AJAX_PROXY_URL }}
+  test-browser:
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+        id: setup-chrome
+      - uses: nanasess/setup-chromedriver@9cd356a368322c0154e5610c8d4a5aa5f3c146f5
+      - run: |
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: google/wireit@setup-github-actions-caching/v1
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install sf CLI
+        run: npm install --global @salesforce/cli
+
+      - name: Setup scratch org
+        env:
+          SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+          SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+        run: |
+          npm run test:setup:org
+
+      - name: Run browser tests with 3 attempts
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 60
+          command: |
+            SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+            SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+            DISPLAY=:99 CHROME_BIN=$(which chrome) \
+            npm run test:browser-ci
+          new_command_on_retry: |
+            SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+            SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+            DISPLAY=:99 CHROME_BIN=$(which chrome) \
+            npm run test:browser-ci:retry
+          retry_on: error
+        env:
+          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+          SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
+          SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
+          SF_AJAX_PROXY_URL: ${{ vars.SF_AJAX_PROXY_URL }}
 
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -87,73 +87,73 @@ jobs:
           npm run build:node:cjs
           npm run typecheck
 
-  # test-node-linux:
-  #   needs: lint-and-typecheck
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node_version: [lts/-1, lts/*, latest]
-  #     fail-fast: false
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ matrix.node_version }}
-  #     - uses: google/wireit@setup-github-actions-caching/v1
-  #
-  #     - name: Install dependencies
-  #       run: npm install
-  #
-  #     - name: Install sf CLI
-  #       run: npm install --global @salesforce/cli
-  #
-  #     - name: Setup scratch org
-  #       env:
-  #         SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
-  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-  #         SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
-  #       run: |
-  #         npx zx scripts/org-setup.mjs
-  #
-  #     - name: Run Node tests
-  #       env:
-  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-  #         SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
-  #         SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
-  #       run: |
-  #         SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-  #         SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-  #         SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-  #         npm run test:node
-  #
-  #     - name: Delete scratch org
-  #       if: always()
-  #       run: sf org delete scratch --target-org jsforce-test-org --no-prompt
+  test-node-linux:
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [lts/-1, lts/*, latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+      - uses: google/wireit@setup-github-actions-caching/v1
 
-  # salesforce-cli-external-nuts:
-  #   needs: test-node-linux
-  #   uses: ./.github/workflows/externalNut.yml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ['ubuntu-latest', 'windows-latest']
-  #       externalProjectGitUrl:
-  #         - https://github.com/salesforcecli/plugin-org
-  #         - https://github.com/salesforcecli/plugin-auth
-  #         - https://github.com/salesforcecli/plugin-data
-  #         - https://github.com/salesforcecli/plugin-user
-  #         - https://github.com/salesforcecli/plugin-custom-metadata
-  #   with:
-  #     externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
-  #     command: 'yarn test:nuts'
-  #     os: ${{ matrix.os }}
-  #     useCache: false
-  #   secrets:
-  #     TESTKIT_AUTH_URL: ${{ secrets.SF_HUB_AUTH_URL }}
-  #     TESTKIT_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
-  #     TESTKIT_JWT_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-  #     TESTKIT_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
-  #     TESTKIT_HUB_INSTANCE: ${{ secrets.SF_HUB_INSTANCE }}
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install sf CLI
+        run: npm install --global @salesforce/cli
+
+      - name: Setup scratch org
+        env:
+          SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+          SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+        run: |
+          npm run test:setup:org
+
+      - name: Run Node tests
+        env:
+          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+          SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
+          SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
+        run: |
+          SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+          SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+          SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+          npm run test:node
+
+      - name: Delete scratch org
+        if: always()
+        run: sf org delete scratch --target-org jsforce-test-org --no-prompt
+
+  salesforce-cli-external-nuts:
+    needs: test-node-linux
+    uses: ./.github/workflows/externalNut.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        externalProjectGitUrl:
+          - https://github.com/salesforcecli/plugin-org
+          - https://github.com/salesforcecli/plugin-auth
+          - https://github.com/salesforcecli/plugin-data
+          - https://github.com/salesforcecli/plugin-user
+          - https://github.com/salesforcecli/plugin-custom-metadata
+    with:
+      externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
+      command: 'yarn test:nuts'
+      os: ${{ matrix.os }}
+      useCache: false
+    secrets:
+      TESTKIT_AUTH_URL: ${{ secrets.SF_HUB_AUTH_URL }}
+      TESTKIT_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+      TESTKIT_JWT_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+      TESTKIT_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+      TESTKIT_HUB_INSTANCE: ${{ secrets.SF_HUB_INSTANCE }}
 
   test-node-windows:
     needs: lint-and-typecheck
@@ -181,7 +181,7 @@ jobs:
           SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
           SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
         run: |
-          npx zx scripts/org-setup.mjs
+          npm run test:setup:org
 
       - name: Run Node tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,61 +5,61 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-browser:
-    needs: lint-and-typecheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
-        id: setup-chrome
-      - uses: nanasess/setup-chromedriver@9cd356a368322c0154e5610c8d4a5aa5f3c146f5
-      - run: |
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - uses: google/wireit@setup-github-actions-caching/v1
-      - name: Install dependencies
-        run: npm install
-
-      - name: Install sf CLI
-        run: npm install --global @salesforce/cli
-
-      - name: Setup scratch org
-        env:
-          SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
-          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-          SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
-        run: |
-          npx zx scripts/org-setup.mjs
-
-      - name: Run browser tests with 3 attempts
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          retry_wait_seconds: 60
-          command: |
-            SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-            SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-            DISPLAY=:99 CHROME_BIN=$(which chrome) \
-            npm run test:browser-ci
-          new_command_on_retry: |
-            SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-            SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-            DISPLAY=:99 CHROME_BIN=$(which chrome) \
-            npm run test:browser-ci:retry
-          retry_on: error
-        env:
-          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-          SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
-          SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
-          SF_AJAX_PROXY_URL: ${{ vars.SF_AJAX_PROXY_URL }}
+  # test-browser:
+  #   needs: lint-and-typecheck
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: browser-actions/setup-chrome@v1
+  #       with:
+  #         chrome-version: stable
+  #       id: setup-chrome
+  #     - uses: nanasess/setup-chromedriver@9cd356a368322c0154e5610c8d4a5aa5f3c146f5
+  #     - run: |
+  #         chromedriver --url-base=/wd/hub &
+  #         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: lts/*
+  #     - uses: google/wireit@setup-github-actions-caching/v1
+  #     - name: Install dependencies
+  #       run: npm install
+  #
+  #     - name: Install sf CLI
+  #       run: npm install --global @salesforce/cli
+  #
+  #     - name: Setup scratch org
+  #       env:
+  #         SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+  #         SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+  #       run: |
+  #         npx zx scripts/org-setup.mjs
+  #
+  #     - name: Run browser tests with 3 attempts
+  #       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+  #       with:
+  #         max_attempts: 3
+  #         timeout_minutes: 30
+  #         retry_wait_seconds: 60
+  #         command: |
+  #           SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+  #           SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+  #           SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+  #           DISPLAY=:99 CHROME_BIN=$(which chrome) \
+  #           npm run test:browser-ci
+  #         new_command_on_retry: |
+  #           SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+  #           SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+  #           SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+  #           DISPLAY=:99 CHROME_BIN=$(which chrome) \
+  #           npm run test:browser-ci:retry
+  #         retry_on: error
+  #       env:
+  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+  #         SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
+  #         SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
+  #         SF_AJAX_PROXY_URL: ${{ vars.SF_AJAX_PROXY_URL }}
 
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -87,12 +87,80 @@ jobs:
           npm run build:node:cjs
           npm run typecheck
 
-  test-node-linux:
+  # test-node-linux:
+  #   needs: lint-and-typecheck
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node_version: [lts/-1, lts/*, latest]
+  #     fail-fast: false
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ matrix.node_version }}
+  #     - uses: google/wireit@setup-github-actions-caching/v1
+  #
+  #     - name: Install dependencies
+  #       run: npm install
+  #
+  #     - name: Install sf CLI
+  #       run: npm install --global @salesforce/cli
+  #
+  #     - name: Setup scratch org
+  #       env:
+  #         SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+  #         SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+  #       run: |
+  #         npx zx scripts/org-setup.mjs
+  #
+  #     - name: Run Node tests
+  #       env:
+  #         SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+  #         SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
+  #         SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
+  #       run: |
+  #         SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
+  #         SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+  #         SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+  #         npm run test:node
+  #
+  #     - name: Delete scratch org
+  #       if: always()
+  #       run: sf org delete scratch --target-org jsforce-test-org --no-prompt
+
+  # salesforce-cli-external-nuts:
+  #   needs: test-node-linux
+  #   uses: ./.github/workflows/externalNut.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ['ubuntu-latest', 'windows-latest']
+  #       externalProjectGitUrl:
+  #         - https://github.com/salesforcecli/plugin-org
+  #         - https://github.com/salesforcecli/plugin-auth
+  #         - https://github.com/salesforcecli/plugin-data
+  #         - https://github.com/salesforcecli/plugin-user
+  #         - https://github.com/salesforcecli/plugin-custom-metadata
+  #   with:
+  #     externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
+  #     command: 'yarn test:nuts'
+  #     os: ${{ matrix.os }}
+  #     useCache: false
+  #   secrets:
+  #     TESTKIT_AUTH_URL: ${{ secrets.SF_HUB_AUTH_URL }}
+  #     TESTKIT_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
+  #     TESTKIT_JWT_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
+  #     TESTKIT_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
+  #     TESTKIT_HUB_INSTANCE: ${{ secrets.SF_HUB_INSTANCE }}
+
+  test-node-windows:
     needs: lint-and-typecheck
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/*]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -121,80 +189,11 @@ jobs:
           SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
           SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
         run: |
-          SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-          SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
-          SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
+          $env:SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') `
+          $env:SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') `
+          $env:SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') `
           npm run test:node
 
       - name: Delete scratch org
         if: always()
         run: sf org delete scratch --target-org jsforce-test-org --no-prompt
-
-  salesforce-cli-external-nuts:
-    needs: test-node-linux
-    uses: ./.github/workflows/externalNut.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-latest', 'windows-latest']
-        externalProjectGitUrl:
-          - https://github.com/salesforcecli/plugin-org
-          - https://github.com/salesforcecli/plugin-auth
-          - https://github.com/salesforcecli/plugin-data
-          - https://github.com/salesforcecli/plugin-user
-          - https://github.com/salesforcecli/plugin-custom-metadata
-    with:
-      externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
-      command: 'yarn test:nuts'
-      os: ${{ matrix.os }}
-      useCache: false
-    secrets:
-      TESTKIT_AUTH_URL: ${{ secrets.SF_HUB_AUTH_URL }}
-      TESTKIT_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
-      TESTKIT_JWT_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
-      TESTKIT_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
-      TESTKIT_HUB_INSTANCE: ${{ secrets.SF_HUB_INSTANCE }}
-
- #  test-node-windows:
- #    needs: lint-and-typecheck
- #    runs-on: windows-latest
- #    strategy:
- #      matrix:
- #        node_version: [lts/*]
- #      fail-fast: false
- #    steps:
- #      - uses: actions/checkout@v3
- #      - uses: actions/setup-node@v3
- #        with:
- #          node-version: ${{ matrix.node_version }}
- #      - uses: google/wireit@setup-github-actions-caching/v1
- #
- #      - name: Install dependencies
- #        run: npm install
- #
- #      - name: Install sf CLI
- #        run: npm install --global @salesforce/cli
- #
- #      - name: Setup scratch org
- #        env:
- #          SF_HUB_USERNAME: ${{ secrets.SF_HUB_USERNAME }}
- #          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
- #          SF_OAUTH2_JWT_KEY: ${{ secrets.SF_OAUTH2_JWT_KEY }}
- #        run: |
- #          npx zx scripts/org-setup.mjs
- #
- #      - name: Run Node tests
- #        env:
- #          SF_OAUTH2_CLIENT_ID: ${{ secrets.SF_OAUTH2_CLIENT_ID }}
- #          SF_OAUTH2_CLIENT_SECRET: ${{ secrets.SF_OAUTH2_CLIENT_SECRET }}
- #          SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
- #        run: |
- #          $env:SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') `
- #          $env:SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') `
- #          $env:SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') `
- #          npm run test:node
- #
- #      - name: Delete scratch org
- #        if: always()
- #        run: sf org delete scratch --target-org jsforce-test-org --no-prompt
- # 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "test:browser": "wireit",
     "test:browser-ci": "wireit",
     "test:browser-ci:retry": "wireit",
+    "test:setup:org": "zx scripts/org-setup.mjs",
     "typecheck": "wireit",
     "proxy-server": "wireit",
     "clean": "rimraf --glob lib/* module/* browser/*",

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -46,7 +46,6 @@ await $`sf org create scratch --definition-file ${orgDefinitionFile} --wait 20 -
 await $`sf org generate password --target-org jsforce-test-org --json`;
 
 await $`sf project deploy start --metadata-dir ${join(
-  process.cwd(),
   'test',
   'package',
   'JSforceTestSuite',

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -28,7 +28,7 @@ if (
 
   await writeFile(hubOpts.jwtKeyFile, formatJwtKey());
 
-  await $`sf org login jwt --username ${hubOpts.username} --jwt-key-file "${hubOpts.jwtKeyFile}" --set-default-dev-hub --client-id ${hubOpts.clientId}`;
+  await $`sf org login jwt --username ${hubOpts.username} --jwt-key-file "jwtKey.txt" --set-default-dev-hub --client-id ${hubOpts.clientId}`;
 } else {
   // ensure there's a default devhub
   const defaultHub = JSON.parse(await $`sf config get target-dev-hub --json`);

--- a/src/api/bulk2.ts
+++ b/src/api/bulk2.ts
@@ -270,15 +270,14 @@ export class BulkV2<S extends Schema> {
     if (!options.pollTimeout) options.pollTimeout = this.pollTimeout;
     if (!options.pollInterval) options.pollInterval = this.pollInterval;
 
-    const job = this.createJob({
-      object: options.object,
-      operation: options.operation,
-    });
+    const { pollInterval, pollTimeout, input, ...createJobOpts } = options;
+
+    const job = this.createJob(createJobOpts);
     try {
       await job.open();
-      await job.uploadData(options.input);
+      await job.uploadData(input);
       await job.close();
-      await job.poll(options.pollInterval, options.pollTimeout);
+      await job.poll(pollInterval, pollTimeout);
       return await job.getAllResults();
     } catch (error) {
       const err = error as Error;

--- a/test/bulk.test.ts
+++ b/test/bulk.test.ts
@@ -153,7 +153,7 @@ if (isNodeJS()) {
   it('should bulk insert from file and return inserted results', async () => {
     // insert 100 account records from csv file
     const fstream = fs.createReadStream(
-      path.join(__dirname, 'data/Account_bulk1_test.csv'),
+      path.join(__dirname, 'data', 'Account_bulk1_test.csv'),
     );
     const batch = conn.bulk.load('Account', 'insert');
     fstream.pipe(batch.stream());
@@ -194,7 +194,7 @@ if (isNodeJS()) {
 
     const data = `Id\n${records.map((r: Record) => r.Id).join('\n')}\n`;
 
-    const deleteFile = path.join(__dirname, 'data/Account_delete.csv');
+    const deleteFile = path.join(__dirname, 'data', 'Account_delete.csv');
 
     await fs.promises.writeFile(deleteFile, data);
 
@@ -221,7 +221,7 @@ if (isNodeJS()) {
   });
 
   it('should bulk query and get records with yielding file output', async () => {
-    const file = path.join(__dirname, '/data/BulkQuery_export.csv');
+    const file = path.join(__dirname, 'data', 'BulkQuery_export.csv');
     const fstream = fs.createWriteStream(file);
     const count = await conn.sobject(config.bigTable).count({});
     const queryStream = await conn.bulk.query(

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import os from 'os';
 import fs from './helper/fs';
 import { Connection, Date as SfDate, Schema, Record } from 'jsforce';
 import ConnectionManager from './helper/connection-manager';
@@ -197,10 +198,11 @@ if (isNodeJS()) {
   it('should bulk insert from file and return inserted results', async () => {
     // insert 100 account records from csv file
     const csvStream = fs.createReadStream(
-      path.join(__dirname, 'data/Account_bulk2_test.csv'),
+      path.join(__dirname, 'data', 'Account_bulk2_test.csv'),
     );
 
     const res = await conn.bulk2.loadAndWaitForResults({
+      lineEnding: os.platform() === 'win32' ? 'CRLF' : 'LF',
       object: 'Account',
       operation: 'insert',
       input: csvStream,
@@ -232,7 +234,7 @@ if (isNodeJS()) {
       .sobject('Account')
       .find({ Name: { $like: `Bulk Account ${id}%` } });
     const data = `Id\n${records.map((r: Record) => r.Id).join('\n')}\n`;
-    const deleteFile = path.join(__dirname, 'data/Account_delete.csv');
+    const deleteFile = path.join(__dirname, 'data', 'Account_delete.csv');
 
     await fs.promises.writeFile(deleteFile, data);
 

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import path from 'path';
-import os from 'os';
 import fs from './helper/fs';
 import { Connection, Date as SfDate, Schema, Record } from 'jsforce';
 import ConnectionManager from './helper/connection-manager';
@@ -202,7 +201,7 @@ if (isNodeJS()) {
     );
 
     const res = await conn.bulk2.loadAndWaitForResults({
-      lineEnding: os.platform() === 'win32' ? 'CRLF' : 'LF',
+      lineEnding: require('os').platform() === 'win32' ? 'CRLF' : 'LF',
       object: 'Account',
       operation: 'insert',
       input: csvStream,


### PR DESCRIPTION
Enable e2e tests on Windows, updated the org-setup script to fix some path issues that where blocking this.

After getting these running I was getting this failure even after setting the correct lineEnding value for windows:
https://github.com/jsforce/jsforce/actions/runs/8818324210/job/24206906041#step:8:645

turns out `bulk2.loadAndWaitForResults` wasn't passing job bodyParams down when creating the job, fixed in this commit:
https://github.com/jsforce/jsforce/commit/8e63fd024c8afe6cf6c2f721072727b91c94aee9

@W-13879927@