### PR TITLE
ci: external NUTs use jsforce-node

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -84,19 +84,19 @@ jobs:
           key: ${{ runner.os }}-externalNuts-${{ env.cache-name }}-${{ inputs.externalProjectGitUrl}}-${{ inputs.branch}}-${{ github.sha }}
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-      - name: build and create symlink to jsforce
+      - name: build and create symlink to jsforce-node
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
         run: |
           cd ./jsforce
           npm install
           ## skip webpack, we are only interested in the node build
-          npm run clean && npm run build:node:cjs
+          npm run clean && npm run jsforce-node && npm run build:node:cjs
           yarn link
-      - name: link jsforce into plugin
+      - name: link jsforce-node into plugin
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
         # this rely on plugins having just 1 version of jsforce
         # in its top-level node_modules.
-        run: yarn link "jsforce"
+        run: yarn link "@jsforce/jsforce-node"
       - name: Build the external project (where the NUTs are)
         run: yarn compile
       - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -5,13 +5,13 @@ import { EOL } from 'node:os';
 
 $.verbose = false;
 
-// node v21 deprecates the `punycode` module:
+// node >= v21 deprecates the `punycode` module:
 // https://nodejs.org/en/blog/announcements/v21-release-announce#deprecations
-// The `sf` CLI is getting it via node-fetch v2 so we disable deprecations on node v21
+// The `sf` CLI is getting it via node-fetch v2 so we disable deprecations on node >= v21
 // to be able to parse JSON output.
 //
 // Remove once `sf` no longer depends on node-fetch v2.
-if (process.version.split('.')[0] === 'v21') {
+if (parseInt(process.versions.node.split('.')[0]) > 21) {
   process.env.NODE_OPTIONS = '--no-deprecation';
 }
 


### PR DESCRIPTION
Updates external NUTs workflow to use jsforce-node instead of jsforce when linking it into sf plugins.

Also fixes org-setup script failing on node v22 (see the failure in the first commit, node-latest run).