### PR TITLE
fix: include RecordStream in `jsforce` class

### DIFF
--- a/src/jsforce.ts
+++ b/src/jsforce.ts
@@ -5,6 +5,7 @@ import OAuth2 from './oauth2';
 import SfDate from './date';
 import registry, { Registry } from './registry';
 import client, { BrowserClient } from './browser/client';
+import { RecordStream } from './record-stream';
 
 /**
  *
@@ -16,6 +17,7 @@ class JSforce extends EventEmitter {
   SfDate: typeof SfDate = SfDate;
   Date: typeof SfDate = SfDate;
   BrowserClient: typeof BrowserClient = BrowserClient;
+  RecordStream: typeof RecordStream = RecordStream;
   registry: Registry = registry;
   browser: BrowserClient = client;
 }


### PR DESCRIPTION
follow up to docs update, when updating this example in the `Advanced` sections here:
https://github.com/jsforce/jsforce-website/pull/23/files#diff-a3471f45ee29622bbcef0e1609f20396694da97b82c406a839b8c776fad94424R117

I found the `jsforce` class in v2 doesn't include `RecordStream`, v1 included it:
https://github.com/jsforce/jsforce/blob/master/lib/core.js#L14

mostly handy for the `filter/map/recordMapStream` static methods that return a node transform stream.