### PR TITLE
fix: throw error if lightning url passed as instance url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.1",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -321,6 +321,11 @@ export class Connection<S extends Schema = Schema> extends EventEmitter {
     } = config;
     this.loginUrl = loginUrl || defaultConnectionConfig.loginUrl;
     this.instanceUrl = instanceUrl || defaultConnectionConfig.instanceUrl;
+
+    if (this.isLightningInstance()) {
+      throw new Error('lightning URLs are not valid as instance URLs');
+    }
+
     this.version = version || defaultConnectionConfig.version;
     this.oauth2 =
       oauth2 instanceof OAuth2
@@ -1599,6 +1604,14 @@ export class Connection<S extends Schema = Schema> extends EventEmitter {
    * Module which manages process rules and approval processes
    */
   process = new Process(this);
+
+  public isLightningInstance(): boolean {
+    return (
+      this.instanceUrl.includes('.lightning.force.com') ||
+      this.instanceUrl.includes('.lightning.crmforce.mil') ||
+      this.instanceUrl.includes('.lightning.sfcrmapps.cn')
+    );
+  }
 }
 
 export default Connection;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1605,7 +1605,7 @@ export class Connection<S extends Schema = Schema> extends EventEmitter {
    */
   process = new Process(this);
 
-  public isLightningInstance(): boolean {
+  private isLightningInstance(): boolean {
     return (
       this.instanceUrl.includes('.lightning.force.com') ||
       this.instanceUrl.includes('.lightning.crmforce.mil') ||

--- a/test/connection-session.test.ts
+++ b/test/connection-session.test.ts
@@ -29,6 +29,54 @@ describe('login', () => {
     assert.ok(typeof userInfo.url === 'string');
   });
 
+  it('should not allow a lightning URL as instance URL', async () => {
+    // .lightning
+    try {
+      conn = new Connection({
+        logLevel: config.logLevel,
+        proxyUrl: config.proxyUrl,
+        loginUrl: config.loginUrl,
+        instanceUrl: 'my-cool-url.lightning.force.com',
+      });
+      assert.fail('the above should throw for a lighting url');
+    } catch (e) {
+      assert.equal(
+        (e as Error).message,
+        'lightning URLs are not valid as instance URLs',
+      );
+    }
+    // .mil
+    try {
+      conn = new Connection({
+        logLevel: config.logLevel,
+        proxyUrl: config.proxyUrl,
+        loginUrl: config.loginUrl,
+        instanceUrl: 'my-cool-url.lightning.crmforce.mil',
+      });
+      assert.fail('the above should throw for a lighting url');
+    } catch (e) {
+      assert.equal(
+        (e as Error).message,
+        'lightning URLs are not valid as instance URLs',
+      );
+    }
+    // for china
+    try {
+      conn = new Connection({
+        logLevel: config.logLevel,
+        proxyUrl: config.proxyUrl,
+        loginUrl: config.loginUrl,
+        instanceUrl: 'my-cool-url.lightning.sfcrmapps.cn',
+      });
+      assert.fail('the above should throw for a lighting url');
+    } catch (e) {
+      assert.equal(
+        (e as Error).message,
+        'lightning URLs are not valid as instance URLs',
+      );
+    }
+  });
+
   //
   it('should execute query and return some records', async () => {
     const res = await conn.query('SELECT Id FROM User');


### PR DESCRIPTION
@W-15748051@
https://github.com/jsforce/jsforce/issues/1352

validates instanceUrls as non lightning before creating connections with them