### PR TITLE
Fix OAuth2 Username-Password Flow when redirectUri is missing

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -210,7 +210,7 @@ export class OAuth2 {
     username: string,
     password: string,
   ): Promise<TokenResponse> {
-    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
+    if (!this.clientId || !this.clientSecret) {
       throw new Error('No valid OAuth2 client configuration set');
     }
     const ret = await this._postParams({
@@ -219,7 +219,6 @@ export class OAuth2 {
       password,
       client_id: this.clientId,
       client_secret: this.clientSecret,
-      redirect_uri: this.redirectUri,
     });
     return ret as TokenResponse;
   }


### PR DESCRIPTION
In OAuth2 Username-Password Flow, `redirectUri` is not required. 

For documentation reference: https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_username_password_flow.htm&type=5