### PR TITLE
docs: set up v3 API ref. site

### DIFF
--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     needs: release
-    if: github.ref_name == '3.0'
+    if: github.ref_name === '3.0' # TODO: remove this line after v3 GA(3.0 should be the main branch)
     uses: ./.github/workflows/publishDocs.yml
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publishDocs.yml
+++ b/.github/workflows/publishDocs.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           rm -rf docs
           git worktree prune
-          git fetch origin v3-docs:v3-docs
-          git worktree add docs v3-docs
+          git fetch origin gh-pages:gh-pages
+          git worktree add docs gh-pages
           npx typedoc --out docs/tmp
           cp -r docs/tmp/* docs/tmp/..
           rm -rf docs/tmp
@@ -34,5 +34,5 @@ jobs:
         run: |
           cd docs
           git add .
-          git commit -m 'docs: publishing v3-docs [skip ci]' --no-verify
-          git push origin v3-docs --no-verify
+          git commit -m 'docs: publishing gh-pages [skip ci]' --no-verify
+          git push origin gh-pages --no-verify

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ Supported Salesforce APIs are the following:
 
 ## Documentation
 
-See documentation in <http://jsforce.github.io/> .
+See documentation in https://jsforce.github.io/
+
+v3 API reference:
+https://jsforce.github.io/jsforce/
+
+v1 API reference:
+https://jsforce.github.io/jsforce/doc/
 
 ## Releases
 

--- a/test/connection-session.test.ts
+++ b/test/connection-session.test.ts
@@ -29,7 +29,7 @@ describe('login', () => {
     assert.ok(typeof userInfo.url === 'string');
   });
 
-  it('should not allow a lightning URL as instance URL', async () => {
+  it('should not allow a lightning URL as instance URL', () => {
     // .lightning
     try {
       conn = new Connection({


### PR DESCRIPTION
Updates typedoc workflow to push site build to `gh-pages`.
I pushed the first build from local to confirm it Jekyll build worked while retaining the v1 API ref at `doc`:
https://github.com/jsforce/jsforce/tree/gh-pages

Changed GH pages it to serve from the root:
![Screenshot 2024-05-20 at 5 47 53 PM](https://github.com/jsforce/jsforce/assets/6853656/4e175e4c-c9fc-4c49-b51a-cc4f03cec219)


v3: https://jsforce.github.io/jsforce/
v1: https://jsforce.github.io/jsforce/doc/

When users click on `API Reference` in https://jsforce.github.io/ they will get to the v3 API ref. The main page is the readme which links to v1 ones.
changed here: https://github.com/jsforce/jsforce.github.io/commit/63913c07f95cd2cd6f0a4a57ff8922f81a974bf7

@W-15807592@