### PR TITLE
fix(bulk): add missing `created` field

### DIFF
--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -86,6 +86,7 @@ export type BulkQueryBatchResult = Array<{
 export type BulkIngestBatchResult = Array<{
   id: string | null;
   success: boolean;
+  created: boolean;
   errors: string[];
 }>;
 
@@ -98,6 +99,7 @@ export type BatchResult<Opr extends BulkOperation> = Opr extends
 type BulkIngestResultResponse = Array<{
   Id: string;
   Success: string;
+  Created: string;
   Error: string;
 }>;
 
@@ -674,6 +676,7 @@ export class Batch<
         results = res.map((ret) => ({
           id: ret.Id || null,
           success: ret.Success === 'true',
+          created: ret.Created === 'true',
           errors: ret.Error ? [ret.Error] : [],
         }));
       }

--- a/test/bulk.test.ts
+++ b/test/bulk.test.ts
@@ -36,6 +36,7 @@ export async function insertAccounts(
   for (const res of batchInsertRes) {
     assert.ok(isString(res.id));
     assert.ok(res.success === true);
+    assert.ok(res.created === true);
   }
 
   return batchInsertRes;


### PR DESCRIPTION
adds missing field to batch results records.

ref https://github.com/jsforce/jsforce/issues/796

Bulk V2 already includes it:
https://github.com/jsforce/jsforce/blob/af8a10e84557d95e20a62dae37e9dbf1e4d50fa8/src/api/bulk2.ts#L71