### PR TITLE
fix(bulk): stop polling if job was aborted

### DIFF
--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -636,7 +636,7 @@ export class Batch<
       } else if (res.state === 'Completed') {
         this.retrieve();
       } else if (res.state === 'NotProcessed') {
-        throw new Error('Job has been aborted');
+        this.emit('error', new Error('Job has been aborted'));
       } else {
         this.emit('inProgress', res);
         setTimeout(poll, interval);

--- a/src/api/bulk.ts
+++ b/src/api/bulk.ts
@@ -37,7 +37,7 @@ export type BulkOptions = {
   assignmentRuleId?: string;
 };
 
-export type JobState = 'Open' | 'Closed' | 'Aborted' | 'Failed' | 'Unknown';
+export type JobState = 'Open' | 'Closed' | 'Aborted' | 'Failed' | 'Unknown' | 'NotProcessed';
 
 export type JobInfo = {
   id: string;
@@ -635,6 +635,8 @@ export class Batch<
         }
       } else if (res.state === 'Completed') {
         this.retrieve();
+      } else if (res.state === 'NotProcessed') {
+        throw new Error('Job has been aborted');
       } else {
         this.emit('inProgress', res);
         setTimeout(poll, interval);


### PR DESCRIPTION
ref https://github.com/jsforce/jsforce/issues/765
Possible bulk job states:
https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_batches_interpret_status.htm


Bulk V2 module already does handles this scenario:
https://github.com/jsforce/jsforce/blob/b661afdd21729812974f1056e392f2f58fc21096/src/api/bulk2.ts#L486