### PR TITLE
fix: `jsforce.VERSION` matches current version

### DIFF
--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -31,6 +31,7 @@ jobs:
           git-user-email: svc_cli_bot@salesforce.com
           github-token: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
           output-file: false
+          pre-commit: ./scripts/bump-version-file.js
           # always do the release, even if there are no semantic commits
           skip-on-empty: false
           tag-prefix: ''

--- a/scripts/bump-version-file.js
+++ b/scripts/bump-version-file.js
@@ -1,0 +1,9 @@
+const fs = require('node:fs/promises');
+
+exports.preCommit = async (props) => {
+  const updatedVersion = (await fs.readFile('./src/VERSION.ts', {
+    encoding: 'utf-8'
+  })).replace(/'[^']*'/g, `'${props.version}'`)
+
+  await fs.writeFile('./src/VERSION.ts', updatedVersion)
+};


### PR DESCRIPTION
Fixes: https://github.com/jsforce/jsforce/issues/1498

This PR adds a pre-commit hook to bump the package version in `src/VERSION.ts` to the one that will be published in the `onRelease` workflow.