### PR TITLE
fix(login): throw if password expired

### DIFF
--- a/test/connection-session.test.ts
+++ b/test/connection-session.test.ts
@@ -4,7 +4,6 @@ import { delay } from './util';
 import authorize from './helper/webauth';
 import config from './config';
 import { isNodeJS } from './helper/env';
-import nock = require('nock');
 
 if (typeof jest !== 'undefined') {
   jest.retryTimes(2);
@@ -28,41 +27,6 @@ describe('login', () => {
     assert.ok(typeof userInfo.id === 'string');
     assert.ok(typeof userInfo.organizationId === 'string');
     assert.ok(typeof userInfo.url === 'string');
-  });
-
-  it('should throw when using an expired password', () => {
-    conn = new Connection({
-      loginUrl: 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com',
-    });
-const passwordExpiredXml =
-`<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-	xmlns="urn:partner.soap.sforce.com"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<soapenv:Body>
-		<loginResponse>
-			<result>
-				<passwordExpired>true</passwordExpired>
-			</result>
-		</loginResponse>
-	</soapenv:Body>
-</soapenv:Envelope>`
-
-      nock(conn.loginUrl)
-        .post('/services/Soap/u/50.0')
-        .reply(200, passwordExpiredXml);
-    assert.rejects(async () => {
-      await conn.login('user','password')
-    }, {
-      message: 'Unable to login because the used password has expired.'
-    })
-
-    // const userInfo = await conn.login(config.username, config.password);
-    // assert.ok(typeof conn.accessToken === 'string');
-    // assert.ok(typeof userInfo.id === 'string');
-    // assert.ok(typeof userInfo.organizationId === 'string');
-    // assert.ok(typeof userInfo.url === 'string');
   });
 
   it('should not allow a lightning URL as instance URL', () => {

--- a/test/connection-session.test.ts
+++ b/test/connection-session.test.ts
@@ -4,6 +4,7 @@ import { delay } from './util';
 import authorize from './helper/webauth';
 import config from './config';
 import { isNodeJS } from './helper/env';
+import nock = require('nock');
 
 if (typeof jest !== 'undefined') {
   jest.retryTimes(2);
@@ -27,6 +28,41 @@ describe('login', () => {
     assert.ok(typeof userInfo.id === 'string');
     assert.ok(typeof userInfo.organizationId === 'string');
     assert.ok(typeof userInfo.url === 'string');
+  });
+
+  it('should throw when using an expired password', () => {
+    conn = new Connection({
+      loginUrl: 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com',
+    });
+const passwordExpiredXml =
+`<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+	xmlns="urn:partner.soap.sforce.com"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<soapenv:Body>
+		<loginResponse>
+			<result>
+				<passwordExpired>true</passwordExpired>
+			</result>
+		</loginResponse>
+	</soapenv:Body>
+</soapenv:Envelope>`
+
+      nock(conn.loginUrl)
+        .post('/services/Soap/u/50.0')
+        .reply(200, passwordExpiredXml);
+    assert.rejects(async () => {
+      await conn.login('user','password')
+    }, {
+      message: 'Unable to login because the used password has expired.'
+    })
+
+    // const userInfo = await conn.login(config.username, config.password);
+    // assert.ok(typeof conn.accessToken === 'string');
+    // assert.ok(typeof userInfo.id === 'string');
+    // assert.ok(typeof userInfo.organizationId === 'string');
+    // assert.ok(typeof userInfo.url === 'string');
   });
 
   it('should not allow a lightning URL as instance URL', () => {

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -651,7 +651,7 @@ describe('SOAP API', () => {
   });
 
   describe('session refresh', () => {
-    it('fails if passwordExpired=true', () => {
+    it('fails if passwordExpired=true', async () => {
       const conn = new Connection({
         loginUrl,
       });
@@ -676,7 +676,7 @@ describe('SOAP API', () => {
         .reply(200, passwordExpiredXml);
 
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         // SOAP login requests will return 200 even with an expired password:
         // https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login_loginresult.htm?q=passwordExpired
         await conn.login('username','password')


### PR DESCRIPTION
fixes:
* https://github.com/jsforce/jsforce/issues/1308
* https://github.com/jsforce/jsforce/issues/1411

Fix bug where trying to `conn.login` with an expired password would cause an infinite loop.

`conn.login` sets a refresh delegate function:
https://github.com/jsforce/jsforce/blob/2621d0b863487056ce25f949ad8d007125ed04b7/src/connection.ts#L507

the func calls `conn.login` and grabs `conn.accessToken`:
https://github.com/jsforce/jsforce/blob/2621d0b863487056ce25f949ad8d007125ed04b7/src/connection.ts#L185

the API returns 200 with `passwordExpired` set to `true` and a restricted access token (you can use it only to set a new password via `setPassword`):
https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login_loginresult.htm

so any subsequent request would trigger an infinite loop refreshing the restricted token.

### testing:

1. run `npm test:setup:org` to get a scratch org for testing, you'll get credentials printed
2. run `sf org open --path 'lightning/setup/SecurityExpirePasswords/home' --target-org jsforce-test-org` and expire all passwords

save this in a file at the root of the jsforce dir and run it with your scratch org creds:
```js
const jsforce = require('./lib/index');

const conn = new jsforce.Connection({
  version: '60.0',
  logLevel: 'DEBUG',
  loginUrl: '<instance-url>',
  instanceUrl: '<instance-url>',
});

(async() => {
  try {
    await conn.login('<username>','<password>')

    await conn.describe("Opportunity");

  } catch(err) {
    throw err
  }
})()
```

in the `3.0` branch you should see it enter in the session-refresh loop and with this branch it should fail on the first `conn.login` call.

Added a UT to cover this scenario.