### PR TITLE
fix(session-refresh): improve error message

### DIFF
--- a/src/session-refresh-delegate.ts
+++ b/src/session-refresh-delegate.ts
@@ -63,6 +63,8 @@ export class SessionRefreshDelegate<S extends Schema> {
       });
       await this._refreshPromise;
       this._logger.info('<refresh complete>');
+    } catch(err) {
+      throw new Error(`Unable to refresh session due to: ${(err as Error).message}`)
     } finally {
       this._refreshPromise = undefined;
       this._lastRefreshedAt = Date.now();

--- a/test/connection-session.test.ts
+++ b/test/connection-session.test.ts
@@ -272,7 +272,7 @@ if (isNodeJS()) {
         assert.fail();
       } catch (err) {
         assert.ok(err instanceof Error);
-        assert.ok(err.name === 'invalid_grant');
+        assert.ok(err.message === 'Unable to refresh session due to: expired access/refresh token');
       }
     });
   });


### PR DESCRIPTION
Any failure coming from `refreshFn` should surface as a session-refresh failure.

Example throwing in `refreshFn`:

## Before

![Screenshot 2024-06-25 at 5 34 42 PM](https://github.com/jsforce/jsforce/assets/6853656/ea58893d-a0ee-4c9d-9674-4d3db265fc58)

## After
![Screenshot 2024-06-25 at 5 35 20 PM](https://github.com/jsforce/jsforce/assets/6853656/e4beb20a-a7e0-4bb6-8e72-01b2d78dc8c2)
