### PR TITLE
fix: improve error handling

### DIFF
--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -295,7 +295,7 @@ export class HttpApi<S extends Schema> extends EventEmitter {
       return errors.Errors.Error;
     }
 
-    return Array.isArray(errors) ? errors[0] : errors;
+    return errors;
   }
 
   /**
@@ -309,6 +309,17 @@ export class HttpApi<S extends Schema> extends EventEmitter {
     } catch (e) {
       // eslint-disable no-empty
     }
+    
+    if (Array.isArray(error)) {
+      if (error.length === 1){
+        error = error[0]
+      } else {
+        return new HttpApiError(
+          `Multiple errors retuned.
+  Check \`error.content\` for the error details`, 'MULTIPLE_API_ERRORS', error)   
+      }
+    }
+
     error =
       typeof error === 'object' &&
       error !== null &&
@@ -330,7 +341,7 @@ See error.content for the full html response.`,
       );
     }
 
-    return new HttpApiError(error.message, error.errorCode, error);
+    return error instanceof HttpApiError ? error : new HttpApiError(error.message, error.errorCode, error);
   }
 }
 

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -330,7 +330,7 @@ See error.content for the full html response.`,
       );
     }
 
-    return new HttpApiError(error.message, error.errorCode);
+    return new HttpApiError(error.message, error.errorCode, error);
   }
 }
 

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -435,6 +435,7 @@ describe('HTTP API', () => {
         {
           errorCode: missingRequiredFieldErr[0].errorCode,
           message: missingRequiredFieldErr[0].message,
+          content: {...missingRequiredFieldErr[0]}
         },
       );
     });


### PR DESCRIPTION
Fixes:
* https://github.com/jsforce/jsforce/discussions/1521
* https://github.com/jsforce/jsforce/issues/861

#1521 : errors throw from jsforce missing details:
error details are included in `error.content`.

#861 : handle multiple errors
Add a new `MULTIPLE_API_ERRORS` error that contains all errors returned by the API in `error.content`.

### TODO:

- [x] add UTs
- [ ] check if there's a way to trigger multiple error response in XML (this PR covers JSON responses).
- [ ] add section about error handling in migration guides