### PR TITLE
fix(oauth2): ensure endpoints are valid

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -100,10 +100,11 @@ export class OAuth2 {
       this.revokeServiceUrl =
         revokeServiceUrl || `${this.loginUrl}/services/oauth2/revoke`;
     } else {
-      this.loginUrl = loginUrl || defaultOAuth2Config.loginUrl;
-      this.authzServiceUrl = `${this.loginUrl}/services/oauth2/authorize`;
-      this.tokenServiceUrl = `${this.loginUrl}/services/oauth2/token`;
-      this.revokeServiceUrl = `${this.loginUrl}/services/oauth2/revoke`;
+      const loginUrlObject = new URL(loginUrl || defaultOAuth2Config.loginUrl);
+      this.loginUrl = loginUrlObject.href
+      this.authzServiceUrl = `${loginUrlObject.origin}/services/oauth2/authorize`;
+      this.tokenServiceUrl = `${loginUrlObject.origin}/services/oauth2/token`;
+      this.revokeServiceUrl = `${loginUrlObject.origin}/services/oauth2/revoke`;
     }
     this.clientId = clientId;
     this.clientSecret = clientSecret;

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -57,20 +57,55 @@ describe('username password flow', () => {
 
 describe('endpoints', () => {
   it('sets valid oauth endpoints', () => {
-    const instanceUrl = 'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';
+    const instanceUrl =
+      'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';
 
     const oauth2 = new OAuth2({
       loginUrl: instanceUrl,
       clientId: '1234test',
-      redirectUri: 'http://localhost:8080/oauthredirect'
-    })
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
 
-    assert.equal(oauth2.authzServiceUrl, `${instanceUrl}/services/oauth2/authorize`);
-    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}/services/oauth2/token`);
-    assert.equal(oauth2.revokeServiceUrl, `${instanceUrl}/services/oauth2/revoke`);
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${instanceUrl}/services/oauth2/authorize`,
+    );
+    assert.equal(
+      oauth2.tokenServiceUrl,
+      `${instanceUrl}/services/oauth2/token`,
+    );
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${instanceUrl}/services/oauth2/revoke`,
+    );
     assert.equal(
       oauth2.getAuthorizationUrl(),
-      `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`
+      `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
     );
-  })
+  });
+
+  it('handles trailing slash in instanceUrl', () => {
+    const instanceUrl =
+      'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com/';
+
+    const oauth2 = new OAuth2({
+      loginUrl: instanceUrl,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${instanceUrl}services/oauth2/authorize`,
+    );
+    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}services/oauth2/token`);
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${instanceUrl}services/oauth2/revoke`,
+    );
+    assert.equal(
+      oauth2.getAuthorizationUrl(),
+      `${instanceUrl}services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
+    );
+  });
 });

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -57,18 +57,20 @@ describe('username password flow', () => {
 
 describe('endpoints', () => {
   it('sets valid oauth endpoints', () => {
+    const instanceUrl = 'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';
+
     const oauth2 = new OAuth2({
-      loginUrl: config.loginUrl,
+      loginUrl: instanceUrl,
       clientId: '1234test',
       redirectUri: 'http://localhost:8080/oauthredirect'
     })
 
-    assert.equal(oauth2.authzServiceUrl, `${config.loginUrl}/services/oauth2/authorize`);
-    assert.equal(oauth2.tokenServiceUrl, `${config.loginUrl}/services/oauth2/token`);
-    assert.equal(oauth2.revokeServiceUrl, `${config.loginUrl}/services/oauth2/revoke`);
+    assert.equal(oauth2.authzServiceUrl, `${instanceUrl}/services/oauth2/authorize`);
+    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}/services/oauth2/token`);
+    assert.equal(oauth2.revokeServiceUrl, `${instanceUrl}/services/oauth2/revoke`);
     assert.equal(
       oauth2.getAuthorizationUrl(),
-      `${config.loginUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=${oauth2.redirectUri}`
+      `${config.loginUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`
     );
   })
 });

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -54,3 +54,21 @@ describe('username password flow', () => {
     assert.ok(isString(res.access_token));
   });
 });
+
+describe('endpoints', () => {
+  it('sets valid oauth endpoints', () => {
+    const oauth2 = new OAuth2({
+      loginUrl: config.loginUrl,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect'
+    })
+
+    assert.equal(oauth2.authzServiceUrl, `${config.loginUrl}/services/oauth2/authorize`);
+    assert.equal(oauth2.tokenServiceUrl, `${config.loginUrl}/services/oauth2/token`);
+    assert.equal(oauth2.revokeServiceUrl, `${config.loginUrl}/services/oauth2/revoke`);
+    assert.equal(
+      oauth2.getAuthorizationUrl(),
+      `${config.loginUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=${oauth2.redirectUri}`
+    );
+  })
+});

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -70,7 +70,7 @@ describe('endpoints', () => {
     assert.equal(oauth2.revokeServiceUrl, `${instanceUrl}/services/oauth2/revoke`);
     assert.equal(
       oauth2.getAuthorizationUrl(),
-      `${config.loginUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`
+      `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`
     );
   })
 });


### PR DESCRIPTION
we got a report from devs running local Salesforce builds that the double-slash in the oauth URL is no longer working (prod has been parsing it successfully for now). This PR updates the oauth class in jsforce to always return a valid URL without the double-slash even if the provided loginURL has it.

![Screenshot 2024-07-12 at 1 39 45 PM](https://github.com/user-attachments/assets/c5c49ea0-05fe-4abc-88af-f023345272df)


### QA
repro:
run `sf org login web -a devhub --dev-debug -r https://localhost:6101` (don't need access to an internal org, just check the URL opened), should get the same as in the screenshot above ⬆️ 

1. checkout this PR and link it into plugin-auth: 
```
npm i && npm run build:node:cjs && npm run jsforce-node:dev
```
2. in plugin-auth, run: `./bin/dev.js  org login web -a devhub -r https://localhost:6101`, you should see the oauth URL without the double-slash:

![Screenshot 2024-07-12 at 1 48 19 PM](https://github.com/user-attachments/assets/23b38e16-e255-4939-b3b2-312c5bcfd93d)


@ W-16215453@