### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,14 +1,18 @@
-name: manual release
+name: create-github-release
 permissions:
   contents: write
 
 on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - '*'
   workflow_dispatch:
 
 jobs:
   docs:
     needs: release
-    if: github.ref_name == '3.0' # TODO: remove this line after v3 GA(3.0 should be the main branch)
     uses: ./.github/workflows/publishDocs.yml
   release:
     runs-on: ubuntu-latest
@@ -30,7 +34,7 @@ jobs:
           git-user-name: svc-cli-bot-jsforce
           git-user-email: svc_cli_bot@salesforce.com
           github-token: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
-          output-file: false
+          output-file: 'CHANGELOG.md'
           pre-commit: ./scripts/bump-version-file.js
           # always do the release, even if there are no semantic commits
           skip-on-empty: false
@@ -47,4 +51,3 @@ jobs:
         with:
           tag_name: ${{ steps.packageVersion.outputs.prop }}
           release_name: ${{ steps.packageVersion.outputs.prop }}
-          prerelease: true

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -2,8 +2,7 @@ name: publish
 
 on:
   release:
-    # TODO: when this goes to main branch, change it to released
-    types: [prereleased]
+    types: [released]
   # support manual release in case something goes wrong and needs to be repeated or tested
   workflow_dispatch:
     inputs:
@@ -31,7 +30,7 @@ jobs:
       - name: Build
         run: npm run clean && npm run build
       - name: Publish
-        run: npm publish --tag next
+        run: npm publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   npm-publish-jsforce-node:
@@ -55,9 +54,5 @@ jobs:
       - name: Build
         run: npm run clean && npm run build:node:cjs
       - name: Publish
-        env:
-          NEXT_VERSION: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           npm publish --tag latest
-          # TODO: remove next line after v3 GA
-          npm dist-tag add @jsforce/jsforce-node@$NEXT_VERSION next

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ See [DEVELOPING.md](./DEVELOPING.md)
 
 Your contributions are welcome: both by reporting issues on [GitHub issues](https://github.com/jsforce/jsforce/issues) or pull-requesting patches.
 
-If you want to implement any additional features, to be added to JSforce to our master branch, which may or may not be merged please first check current [opening issues](https://github.com/jsforce/jsforce/issues?q=is%3Aopen) with milestones and confirm whether the feature is on road map or not.
+If you want to implement any additional features, to be added to JSforce to our main branch, which may or may not be merged please first check current [opening issues](https://github.com/jsforce/jsforce/issues?q=is%3Aopen) with milestones and confirm whether the feature is on road map or not.
 
 If your feature implementation is brand-new or fixing unsupposed bugs in the library's test cases, please include additional test codes in the `test/` directory.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/jsforce/jsforce/raw/master/LICENSE"
+      "url": "http://github.com/jsforce/jsforce/raw/main/LICENSE"
     }
   ],
   "main": "./index",


### PR DESCRIPTION
Prepare for GA:

* updates release workflows to publish v3 as `latest`
* rename `manualRelease.yml`, will now run on push to `main`