### PR TITLE
chore(ci): update workflows

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -36,8 +36,6 @@ jobs:
           github-token: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
           output-file: 'CHANGELOG.md'
           pre-commit: ./scripts/bump-version-file.js
-          # always do the release, even if there are no semantic commits
-          skip-on-empty: false
           tag-prefix: ''
       - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
         id: packageVersion
@@ -50,4 +48,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.packageVersion.outputs.prop }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
           release_name: ${{ steps.packageVersion.outputs.prop }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: tests
 on:
   push:
-    branches-ignore: [2.0]
+    branches-ignore: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GHA workflow updates

* `create-github-release`: skip empty releases (leftover from the beta period)
* `create-github-release`: set release notes for GH releases
* `tests`: skip tests on `main` (we never push to `main` directly 😉 )

[skip ci]