### PR TITLE
feat(http-proxy): support lowercase env vars

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -21,7 +21,7 @@ function normalizeApiHost(apiHost: string) {
 }
 
 setDefaults({
-  httpProxy: process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? undefined,
+  httpProxy: process.env.https_proxy ?? process.env.http_proxy ?? process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? undefined,
   timeout: process.env.HTTP_TIMEOUT
     ? parseInt(process.env.HTTP_TIMEOUT, 10)
     : undefined,


### PR DESCRIPTION
Adds support for `https_proxy` and `http_proxy` env vars.

These lowercase ones take precedence over uppercase ones, follows the same behavior in:

proxy-from-env: https://github.com/Rob--W/proxy-from-env/blob/095d1c26902f37a12e22bea1b8c6b67bf13fe8cd/index.js#L104

undici: https://github.com/nodejs/undici/blob/eadf7812037f60006ccde087c91b85d54b1bce7f/lib/dispatcher/env-http-proxy-agent.js#L35

@W-15736851@
