### PR TITLE
fix: use logger instead of `console.error`

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -2,6 +2,7 @@ import type { Registry } from './types';
 import { FileRegistry } from './file';
 import { SfdxRegistry } from './sfdx';
 import { EmptyRegistry } from './empty';
+import { getLogger } from '../util/logger';
 
 let registry: Registry;
 try {
@@ -10,7 +11,7 @@ try {
       ? new SfdxRegistry({})
       : new FileRegistry({});
 } catch (e) {
-  console.error(e);
+  getLogger('registry').error(e);
   registry = new EmptyRegistry();
 }
 


### PR DESCRIPTION
I found Error log in CloudWatch Logs  because of `cosole.error`.

https://github.com/jsforce/jsforce/issues/979#issuecomment-2231952572