### PR TITLE
fix: try removing // from URl

### DIFF
--- a/src/api/bulk2.ts
+++ b/src/api/bulk2.ts
@@ -549,7 +549,8 @@ export class QueryJobV2<S extends Schema> extends EventEmitter {
       const resPromise = this.createQueryRequest({
         method: 'GET',
         path: this.locator
-          ? `/${resultsPath}?locator=${this.locator}`
+          // resultsPath starts with '/'
+          ? `${resultsPath}?locator=${this.locator}`
           : resultsPath,
         headers: {
           Accept: 'text/csv',


### PR DESCRIPTION
@W-16325607@
https://github.com/forcedotcom/cli/issues/2968

removes a `//` from URLs when getting query results, not sure if this will fix the issue. I was never able to reproduce it, but saw this in the logs

`query//750Hn00000OUfXPIA1/results?locator=MDowR2`

now 

`query/750Hn00000OUfXPIA1/results?locator=MDowR2`