### PR TITLE
Adding ability to provide type of record for Connection.queryMore method

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -831,8 +831,8 @@ export class Connection<S extends Schema = Schema> extends EventEmitter {
   /**
    *
    */
-  queryMore(locator: string, options?: QueryOptions) {
-    return new Query<S, SObjectNames<S>, Record, 'QueryResult'>(
+  queryMore<T extends Record>(locator: string, options?: QueryOptions) {
+    return new Query<S, SObjectNames<S>, T, 'QueryResult'>(
       this,
       { locator },
       options,


### PR DESCRIPTION
Fix provides ability to set type of Record returned from `queryMore()` method. This is same functionality as `query()`.