### PR TITLE
chore(deps): replace strip-ansi with native Node API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.1",
@@ -24,7 +24,6 @@
         "multistream": "^3.1.0",
         "node-fetch": "^2.6.1",
         "open": "^7.0.0",
-        "strip-ansi": "^6.0.0",
         "xml2js": "^0.6.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -228,7 +228,6 @@
     "multistream": "^3.1.0",
     "node-fetch": "^2.6.1",
     "open": "^7.0.0",
-    "strip-ansi": "^6.0.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/src/registry/sfdx.ts
+++ b/src/registry/sfdx.ts
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'util';
 import Connection from '../connection';
 import { Registry, ConnectionConfig, ClientConfig } from './types';
 import { Schema } from '../types';
@@ -78,7 +78,7 @@ export class SfdxRegistry implements Registry {
         }
       });
     });
-    const body = stripAnsi(buf.toString());
+    const body = stripVTControlCharacters(buf.toString());
     let ret: SfdxCommandOutput;
     try {
       ret = JSON.parse(body) as SfdxCommandOutput;


### PR DESCRIPTION
## Overview

This pull request replaces `strip-ansi` with [`util.stripVTControlCharacters`](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) native API available since Node 16.11.

This change will reduce the amount of dependencies installed by 1