### PR TITLE
feat(bulk2): allow to get raw job results

### DIFF
--- a/src/api/bulk2.ts
+++ b/src/api/bulk2.ts
@@ -863,7 +863,21 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    *
    * @returns Promise<IngestJobV2SuccessfulResults>
    */
-  async getSuccessfulResults(): Promise<IngestJobV2SuccessfulResults<S>> {
+  async getSuccessfulResults(raw?: false): Promise<IngestJobV2SuccessfulResults<S>>
+  async getSuccessfulResults(raw: true): Promise<string>
+  async getSuccessfulResults(raw?: boolean): Promise<IngestJobV2SuccessfulResults<S> | string> {
+    const reqOpts: BulkRequest = {
+      method: 'GET',
+      path: `/${this.id}/successfulResults`,
+    }
+
+    if (raw) {
+      return this.createIngestRequest<string>({
+        ...reqOpts,
+        responseType: 'text/plain',
+      })
+    }
+
     if (this.bulkJobSuccessfulResults) {
       return this.bulkJobSuccessfulResults;
     }
@@ -873,7 +887,7 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
     >({
       method: 'GET',
       path: `/${this.id}/successfulResults`,
-      responseType: 'text/csv',
+      responseType: raw ? 'text/plain' : 'text/csv',
     });
 
     this.bulkJobSuccessfulResults = results ?? [];
@@ -887,7 +901,21 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    *
    * @returns Promise<IngestJobV2SuccessfulResults>
    */
-  async getFailedResults(): Promise<IngestJobV2FailedResults<S>> {
+  async getFailedResults(raw?: false): Promise<IngestJobV2FailedResults<S>>
+  async getFailedResults(raw: true): Promise<string>
+  async getFailedResults(raw?: boolean): Promise<IngestJobV2FailedResults<S> | string> {
+    const reqOpts: BulkRequest = {
+      method: 'GET',
+      path: `/${this.id}/failedResults`,
+    }
+
+    if (raw) {
+      return this.createIngestRequest<string>({
+        ...reqOpts,
+        responseType: 'text/plain',
+      })
+    }
+
     if (this.bulkJobFailedResults) {
       return this.bulkJobFailedResults;
     }
@@ -895,8 +923,7 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
     const results = await this.createIngestRequest<
       IngestJobV2FailedResults<S> | undefined
     >({
-      method: 'GET',
-      path: `/${this.id}/failedResults`,
+      ...reqOpts,
       responseType: 'text/csv',
     });
 
@@ -916,7 +943,21 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    *
    * @returns Promise<IngestJobV2UnprocessedRecords>
    */
-  async getUnprocessedRecords(): Promise<IngestJobV2UnprocessedRecords<S>> {
+  async getUnprocessedRecords(raw?: false): Promise<IngestJobV2UnprocessedRecords<S>>
+  async getUnprocessedRecords(raw: true): Promise<string>
+  async getUnprocessedRecords(raw?: boolean): Promise<IngestJobV2UnprocessedRecords<S>> {
+    const reqOpts: BulkRequest = {
+      method: 'GET',
+      path: `/${this.id}/unprocessedrecords`,
+    }
+
+    if (raw) {
+      return this.createIngestRequest<string>({
+        ...reqOpts,
+        responseType: 'text/plain',
+      })
+    }
+
     if (this.bulkJobUnprocessedRecords) {
       return this.bulkJobUnprocessedRecords;
     }
@@ -924,8 +965,7 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
     const results = await this.createIngestRequest<
       IngestJobV2UnprocessedRecords<S> | undefined
     >({
-      method: 'GET',
-      path: `/${this.id}/unprocessedrecords`,
+      ...reqOpts,
       responseType: 'text/csv',
     });
 

--- a/src/api/bulk2.ts
+++ b/src/api/bulk2.ts
@@ -887,7 +887,7 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
     >({
       method: 'GET',
       path: `/${this.id}/successfulResults`,
-      responseType: raw ? 'text/plain' : 'text/csv',
+      responseType: 'text/csv',
     });
 
     this.bulkJobSuccessfulResults = results ?? [];

--- a/src/api/bulk2.ts
+++ b/src/api/bulk2.ts
@@ -861,9 +861,17 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    *
    * The order of records returned is not guaranteed to match the ordering of the uploaded data.
    *
+   * @param {boolean} raw Get results as a CSV string
    * @returns Promise<IngestJobV2SuccessfulResults>
    */
   async getSuccessfulResults(raw?: false): Promise<IngestJobV2SuccessfulResults<S>>
+  /** Return successful results
+   *
+   * The order of records returned is not guaranteed to match the ordering of the uploaded data.
+   *
+   * @param {boolean} raw Get results as a CSV string
+   * @returns Promise<string>
+   */
   async getSuccessfulResults(raw: true): Promise<string>
   async getSuccessfulResults(raw?: boolean): Promise<IngestJobV2SuccessfulResults<S> | string> {
     const reqOpts: BulkRequest = {
@@ -899,9 +907,17 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    *
    * The order of records in the response is not guaranteed to match the ordering of records in the original job data.
    *
+   * @param {boolean} raw Get results as a CSV string
    * @returns Promise<IngestJobV2SuccessfulResults>
    */
   async getFailedResults(raw?: false): Promise<IngestJobV2FailedResults<S>>
+  /** Return failed results
+   *
+   * The order of records in the response is not guaranteed to match the ordering of records in the original job data.
+   *
+   * @param {boolean} raw Get results as a CSV string
+   * @returns Promise<string>
+   */
   async getFailedResults(raw: true): Promise<string>
   async getFailedResults(raw?: boolean): Promise<IngestJobV2FailedResults<S> | string> {
     const reqOpts: BulkRequest = {
@@ -937,13 +953,26 @@ export class IngestJobV2<S extends Schema> extends EventEmitter {
    * The unprocessed records endpoint returns records as a CSV.
    * If the request helper is able to parse it, you get the records
    * as an array of objects.
-   * If unable to parse the it (bad CSV), you get the raw response as a string.
+   * If unable to parse it (bad CSV), you get the raw response as a string.
    *
    * The order of records in the response is not guaranteed to match the ordering of records in the original job data.
    *
+   * @param {boolean} raw Get results as a CSV string
    * @returns Promise<IngestJobV2UnprocessedRecords>
    */
   async getUnprocessedRecords(raw?: false): Promise<IngestJobV2UnprocessedRecords<S>>
+    /** Return unprocessed results
+   *
+   * The unprocessed records endpoint returns records as a CSV.
+   * If the request helper is able to parse it, you get the records
+   * as an array of objects.
+   * If unable to parse it (bad CSV), you get the raw response as a string.
+   *
+   * The order of records in the response is not guaranteed to match the ordering of records in the original job data.
+   *
+   * @param {boolean} raw Get results as a CSV string
+   * @returns Promise<string>
+   */
   async getUnprocessedRecords(raw: true): Promise<string>
   async getUnprocessedRecords(raw?: boolean): Promise<IngestJobV2UnprocessedRecords<S>> {
     const reqOpts: BulkRequest = {


### PR DESCRIPTION
Allow to fetch raw CSV results from bulk2 jobs.

The getResults method would fetch the CSV, parse them into JS arrays and cache that in an internal class field, this PR adds support for these methods to return results a CSV (string) and intentionally skip caching to avoid switching types.

Required for:
https://github.com/salesforcecli/plugin-data/pull/1097

@W-12408034@