### PR TITLE
fix(oauth2): don't strip URL path

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -102,9 +102,12 @@ export class OAuth2 {
     } else {
       const loginUrlObject = new URL(loginUrl || defaultOAuth2Config.loginUrl);
       this.loginUrl = loginUrlObject.href
-      this.authzServiceUrl = `${loginUrlObject.origin}/services/oauth2/authorize`;
-      this.tokenServiceUrl = `${loginUrlObject.origin}/services/oauth2/token`;
-      this.revokeServiceUrl = `${loginUrlObject.origin}/services/oauth2/revoke`;
+
+      const hasPathname = loginUrlObject.pathname !== '/'
+
+      this.authzServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/authorize` : 'services/oauth2/authorize', loginUrlObject.href).toString()
+      this.tokenServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/token` : 'services/oauth2/token', loginUrlObject.href).toString();
+      this.revokeServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/revoke` : 'services/oauth2/revoke', loginUrlObject.href).toString();
     }
     this.clientId = clientId;
     this.clientSecret = clientSecret;

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -100,14 +100,13 @@ export class OAuth2 {
       this.revokeServiceUrl =
         revokeServiceUrl || `${this.loginUrl}/services/oauth2/revoke`;
     } else {
-      const loginUrlObject = new URL(loginUrl || defaultOAuth2Config.loginUrl);
-      this.loginUrl = loginUrlObject.href
+      this.loginUrl = loginUrl ?? defaultOAuth2Config.loginUrl
 
-      const hasPathname = loginUrlObject.pathname !== '/'
+      const maybeSlash = this.loginUrl.endsWith('/') ? '' : '/'
 
-      this.authzServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/authorize` : 'services/oauth2/authorize', loginUrlObject.href).toString()
-      this.tokenServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/token` : 'services/oauth2/token', loginUrlObject.href).toString();
-      this.revokeServiceUrl = new URL(hasPathname ? `${loginUrlObject.pathname}/services/oauth2/revoke` : 'services/oauth2/revoke', loginUrlObject.href).toString();
+      this.authzServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/authorize`
+      this.tokenServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/token`
+      this.revokeServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/revoke`
     }
     this.clientId = clientId;
     this.clientSecret = clientSecret;

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -55,7 +55,7 @@ describe('username password flow', () => {
   });
 });
 
-describe.only('endpoints', () => {
+describe('endpoints', () => {
   it('sets valid oauth endpoints', () => {
     const instanceUrl =
       'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -55,7 +55,7 @@ describe('username password flow', () => {
   });
 });
 
-describe('endpoints', () => {
+describe.only('endpoints', () => {
   it('sets valid oauth endpoints', () => {
     const instanceUrl =
       'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';
@@ -112,26 +112,26 @@ describe('endpoints', () => {
 
   it('handles trailing slash in instanceUrl', () => {
     const instanceUrl =
-      'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com/';
+      'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com';
 
     const oauth2 = new OAuth2({
-      loginUrl: instanceUrl,
+      loginUrl: instanceUrl + '/',
       clientId: '1234test',
       redirectUri: 'http://localhost:8080/oauthredirect',
     });
 
     assert.equal(
       oauth2.authzServiceUrl,
-      `${instanceUrl}services/oauth2/authorize`,
+      `${instanceUrl}/services/oauth2/authorize`,
     );
-    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}services/oauth2/token`);
+    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}/services/oauth2/token`);
     assert.equal(
       oauth2.revokeServiceUrl,
-      `${instanceUrl}services/oauth2/revoke`,
+      `${instanceUrl}/services/oauth2/revoke`,
     );
     assert.equal(
       oauth2.getAuthorizationUrl(),
-      `${instanceUrl}services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
+      `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
     );
   });
 });

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -84,6 +84,32 @@ describe('endpoints', () => {
     );
   });
 
+  it('does not strip URL path', () => {
+    const instanceUrl =
+      'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com/AppCentral';
+
+    const oauth2 = new OAuth2({
+      loginUrl: instanceUrl,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${instanceUrl}/services/oauth2/authorize`,
+    );
+    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}/services/oauth2/token`);
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${instanceUrl}/services/oauth2/revoke`,
+    );
+    assert.equal(
+      oauth2.getAuthorizationUrl(),
+      `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
+    );
+
+  })
+
   it('handles trailing slash in instanceUrl', () => {
     const instanceUrl =
       'https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com/';


### PR DESCRIPTION
Allow the OAuth2 module to handle supported URLs:
> All OAuth endpoints require secure HTTP (HTTPS). For standard OAuth 2.0 authorization flows, these host domains are supported unless otherwise specified.
login.salesforce.com
A My Domain URL, such as https://MyCompany.my.salesforce.com
An Experience Cloud site URL, such as https://MyDomainName.my.site.com
A custom URL
For sandboxes, use test.salesforce.com or the My Domain login URL for the sandbox, such as MyDomainName--SandboxName.sandbox.my.salesforce.com.

https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_endpoints.htm&type=5

### before

A community URL like `https://innovation-momentum-8840-dev-ed.scratch.my.salesforce.com/AppCentral` would get the pathname (`/AppCentral`) trimmed.

### after

URL pathname is kept, jsforce handles possible trialing slash.

@W-17041779@