### PR TITLE
fix(http): handle more CSV delimiters on parse

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -10,11 +10,17 @@ import {
 } from 'csv-stringify';
 import { stringify as csvStringifySync } from 'csv-stringify/sync';
 
+// The following column delimiters are supported by the Bulk V2 API:
+// https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/create_job.htm
+//
+// BACKQUOTE, CARET, COMMA, PIPE, SEMICOLON, TAB
+const csvDelimiters = ['`','^',',','|',';','	']
+
 /**
  * @private
  */
 export function parseCSV(str: string, options?: ParseOpts): Object[] {
-  return csvParseSync(str, { ...options, columns: true });
+  return csvParseSync(str, { ...options, columns: true, delimiter: csvDelimiters });
 }
 
 /**

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -48,7 +48,7 @@ function ensureSuccessfulBulkResults(
   assert.ok(Array.isArray(successfulResults));
   assert.ok(successfulResults.length === qty);
 
-  const recordCreated = operation === 'insert' ? 'true' : 'false';
+  const recordCreated = ['insert', 'upsert'].includes(operation) ? 'true' : 'false';
 
   for (const successfulResult of successfulResults) {
     assert.ok(isString(successfulResult.sf__Id));
@@ -225,28 +225,48 @@ if (isNodeJS()) {
     }
   });
 
-  it('should bulk delete from file and return deleted results', async () => {
-    const id = Date.now();
+  it('should bulk insert from file and return inserted results', async () => {
+    // insert 100 account records from csv file
+    const csvStream = fs.createReadStream(
+      path.join(__dirname, 'data', 'Account_bulk2_test.csv'),
+    );
 
-    await insertAccounts(id);
+    const res = await conn.bulk2.loadAndWaitForResults({
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      lineEnding: require('os').platform() === 'win32' ? 'CRLF' : 'LF',
+      object: 'Account',
+      operation: 'insert',
+      input: csvStream,
+    });
 
-    const records = await conn
-      .sobject('Account')
-      .find({ Name: { $like: `Bulk Account ${id}%` } });
-    const data = `Id\n${records.map((r: Record) => r.Id).join('\n')}\n`;
-    const deleteFile = path.join(__dirname, 'data', 'Account_delete.csv');
+    try {
+      ensureSuccessfulBulkResults(res, 100, 'insert');
+    } finally {
+      // cleanup:
+      // always delete successfully inserted records.
+      const deleteRecords = res.successfulResults.map((r) => ({
+        Id: r.sf__Id,
+      }));
 
-    await fs.promises.writeFile(deleteFile, data);
+      await conn.bulk2.loadAndWaitForResults({
+        object: 'Account',
+        operation: 'delete',
+        input: deleteRecords,
+      });
+    }
+  })
 
-    const fstream = fs.createReadStream(deleteFile);
+  it('should bulk upsert from CSV file using backquote as a delimiter', async () => {
+    const fstream = fs.createReadStream(path.join(__dirname, 'data', 'Account_bulk2_test_backquote.csv'));
     const res = await conn.bulk2.loadAndWaitForResults({
       object: 'Account',
-      operation: 'delete',
+      operation: 'upsert',
+      columnDelimiter: 'BACKQUOTE',
+      externalIdFieldName: 'Id',
       input: fstream,
     });
 
-    ensureSuccessfulBulkResults(res, 20, 'delete');
-    await fs.promises.rm(deleteFile);
+    ensureSuccessfulBulkResults(res, 10, 'upsert');
   });
 
   it('should bulk query and get records', async () => {

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -263,6 +263,7 @@ if (isNodeJS()) {
       operation: 'upsert',
       columnDelimiter: 'BACKQUOTE',
       externalIdFieldName: 'Id',
+      lineEnding: require('os').platform() === 'win32' ? 'CRLF' : 'LF',
       input: fstream,
     });
 

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -8,7 +8,6 @@ import { isObject, isString } from './util';
 import { isNodeJS } from './helper/env';
 import { BulkOperation } from 'jsforce/lib/api/bulk';
 import { IngestJobV2Results } from 'jsforce/lib/api/bulk2';
-import { platform } from 'node:os';
 
 const connMgr = new ConnectionManager(config);
 const conn = connMgr.createConnection();
@@ -264,7 +263,8 @@ if (isNodeJS()) {
       operation: 'upsert',
       columnDelimiter: 'BACKQUOTE',
       externalIdFieldName: 'Id',
-      lineEnding: platform() === 'win32' ? 'CRLF' : 'LF',
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      lineEnding: require('node:os').platform() === 'win32' ? 'CRLF' : 'LF',
       input: fstream,
     });
 

--- a/test/bulk2.test.ts
+++ b/test/bulk2.test.ts
@@ -8,6 +8,7 @@ import { isObject, isString } from './util';
 import { isNodeJS } from './helper/env';
 import { BulkOperation } from 'jsforce/lib/api/bulk';
 import { IngestJobV2Results } from 'jsforce/lib/api/bulk2';
+import { platform } from 'node:os';
 
 const connMgr = new ConnectionManager(config);
 const conn = connMgr.createConnection();
@@ -263,7 +264,7 @@ if (isNodeJS()) {
       operation: 'upsert',
       columnDelimiter: 'BACKQUOTE',
       externalIdFieldName: 'Id',
-      lineEnding: require('os').platform() === 'win32' ? 'CRLF' : 'LF',
+      lineEnding: platform() === 'win32' ? 'CRLF' : 'LF',
       input: fstream,
     });
 

--- a/test/data/Account_bulk2_test_backquote.csv
+++ b/test/data/Account_bulk2_test_backquote.csv
@@ -1,0 +1,11 @@
+NAME`TYPE`PHONE`WEBSITE`ANNUALREVENUE
+account #0`Account`415-555-0000`http://www.accountUpsert0.com`0
+account #1`Account`415-555-0000`http://www.accountUpsert1.com`1000
+account #2`Account`415-555-0000`http://www.accountUpsert2.com`2000
+account #3`Account`415-555-0000`http://www.accountUpsert3.com`3000
+account #4`Account`415-555-0000`http://www.accountUpsert4.com`4000
+account #5`Account`415-555-0000`http://www.accountUpsert5.com`5000
+account #6`Account`415-555-0000`http://www.accountUpsert6.com`6000
+account #7`Account`415-555-0000`http://www.accountUpsert7.com`7000
+account #8`Account`415-555-0000`http://www.accountUpsert8.com`8000
+account #9`Account`415-555-0000`http://www.accountUpsert9.com`9000


### PR DESCRIPTION
Add known CSV delimiters to the CSV parse helper used to parse a request body.

csv-parse:
https://csv.js.org/parse/options/delimiter/

for `sf data upsert/delete bulk` we call `job.getAllResults()` expecting the CSV result records as JS values but if a user uploaded a CSV file using a delimiter other than `COMMA` then the CSV parser here would fail and we get back the CSV as a string:
https://github.com/jsforce/jsforce/blob/0bbf6313628ff5380138ea5df23b06a59d4fe58c/src/http-api.ts#L220


https://github.com/salesforcecli/plugin-data/pull/1110

@W-16971607@