### PR TITLE
fix: deprecated errorCode prop of type SaveError and added statusCode prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.1",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -212,7 +212,7 @@ function createUsernamePasswordRefreshFn<S extends Schema>(
 function toSaveResult(err: SaveError): SaveResult {
   return {
     success: false,
-    errors: [err],
+    errors: [{ ...err, errorCode: err.statusCode }],
   };
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -1131,6 +1131,7 @@ export class Query<
         errors: [
           {
             errorCode: r.sf__Error,
+            statusCode: r.sf__Error,
             message: r.sf__Error,
           },
         ],

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -66,7 +66,9 @@ export type Record = {
 export type SavedRecord = Record & { Id: string };
 
 export type SaveError = {
+  /** @deprecated use {@link SaveError.statusCode} instead */
   errorCode: string;
+  statusCode: string;
   message: string;
   fields?: string[];
 };


### PR DESCRIPTION
Hello! 👋

I'm an engineer at nCino, and I noticed the `SaveError` type has an incorrect property of `errorCode` that does not match the return value from the SF APIs. [As per the documentation](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database_error.htm#apex_methods_system_database_error), the `errorCode` property should be `statusCode`. This is consistent with the actual error returned: 

```
{\"success\":false,\"errors\":[{\"statusCode\":\"UNABLE_TO_LOCK_ROW\",\"message\":\"unable to obtain exclusive access to this record\",\"fields\":[]}]}
```

This PR adds the `statusCode` field and marks the `errorCode` field as deprecated to avoid a breaking change.