### PR TITLE
fix: skip session refresh on bad Agent API reqs W-17875499

### DIFF
--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -266,7 +266,9 @@ export class HttpApi<S extends Schema> extends EventEmitter {
    * @protected
    */
   isSessionExpired(response: HttpResponse) {
-    return response.statusCode === 401;
+    // TODO:
+    // The connected app msg only applies to Agent API requests, we should move this to a separate SFAP/Agent API class later.
+    return response.statusCode === 401 && !response.body.includes('Connected app is not attached to Agent')
   }
 
   /**


### PR DESCRIPTION
Temporal fix to make jsforce exit early on Agent API requests where the agent being queried doesn't have a connected app linked and keeps returning `401` (infinite session-refresh loop).
Example response from curl:
```
{"status":401,"path":"v6.0.0/agents/<id>/sessions","mode":"unknown","requestId":"3c982dec-4502-4d4c-9efb-ea1bb1b601b0","error":"UnauthorizedException","message":"Connected app is not attached to Agent","timestamp":1740073984584,"expected":false}
```

testing:
checkout locally and build jsforce-node, see:
https://github.com/jsforce/jsforce/blob/main/DEVELOPING.md#getting-started
then link it into sfdx-core

@W-17875499@