### PR TITLE
fix(http): return res/err after retry is done W-17919119

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -77,9 +77,7 @@ async function startFetchRequest(
     if (resOrErr instanceof Response) {
       if (retryOpts.statusCodes.includes(resOrErr.status)) {
         if (maxRetry === retryCount) {
-          const err = new Error('Request failed');
-          err.name = 'RequestRetryError';
-          throw err;
+          return false
         } else {
           return true;
         }
@@ -172,9 +170,7 @@ async function startFetchRequest(
       logger.debug('Skipping retry...');
 
       if (maxRetry === retryCount) {
-        const error = new Error('Request failed', { cause: err });
-        error.name = 'RequestRetryError';
-        throw error;
+        throw err;
       } else {
         throw err;
       }


### PR DESCRIPTION
Fixes: https://github.com/jsforce/jsforce/issues/1642

Removes the bad `RequestRetryError` error (sorry about it, can't remember why I added it tbh).
If a request still fails and reaches the max retry limit we now return the response (or node-fetch error) instead of the generic error.

Example on with `sf` on agent test API returning 500:

```
➜  plugin-agent git:(main) sf api request rest services/data/v63.0/einstein/ai-evaluations/runs/4KBed000000b3erGAA
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
[
  {
    "errorCode": "INTERNAL_SERVER_ERROR",
    "message": "Invalid AiEvaluation identifier"
  }
]
```

### before
```
➜  plugin-agent git:(main) ./bin/run.js agent test resume --job-id 4KBed000000b3erGAA
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.

 ─────── Agent Test Run: 4KBed000000b3erGAA ───────

 ✔ Starting Tests 23ms
 ✘ Polling for Test Results 4.92s
   ▸ Status: ✘
   ▸ Completed Test Cases: ✘
   ▸ Passing Test Cases: ✘
   ▸ Failing Test Cases: ✘

 Job ID: 4KBed000000b3erGAA
 Elapsed Time: 4.97s

Error (1): Request failed
```

### after
```
➜  plugin-agent git:(main) ./bin/run.js agent test resume --job-id 4KBed000000b3erGAA
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.

 ─────── Agent Test Run: 4KBed000000b3erGAA ───────

 ✔ Starting Tests 23ms
 ✘ Polling for Test Results 4.59s
   ▸ Status: ✘
   ▸ Completed Test Cases: ✘
   ▸ Passing Test Cases: ✘
   ▸ Failing Test Cases: ✘

 Job ID: 4KBed000000b3erGAA
 Elapsed Time: 4.68s

Error (1): Invalid AiEvaluation identifier
```

@W-17919119@