### PR TITLE
feat: add checkDeployStatus for REST W-18012955

### DIFF
--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -453,20 +453,33 @@ export class MetadataApi<S extends Schema> {
   }
 
   /**
-   * Checks the status of declarative metadata call deploy()
+   * Checks the status of declarative metadata call deploy(), using either
+   * SOAP or REST APIs.  SOAP is the default.
    */
-  checkDeployStatus(
+  async checkDeployStatus(
     asyncProcessId: string,
     includeDetails: boolean = false,
+    rest: boolean = false,
   ): Promise<DeployResult> {
-    return this._invoke(
-      'checkDeployStatus',
-      {
-        asyncProcessId,
-        includeDetails,
-      },
-      ApiSchemas.DeployResult,
-    );
+    if (rest) {
+      const url = `/metadata/deployRequest/${asyncProcessId}${includeDetails ? '?includeDetails=true' : ''}`;
+      type CheckDeployStatusRest = {
+        id: string;
+        validatedDeployRequestId: string | null;
+        deployResult: DeployResult;
+        deployOptions: DeployOptions | null;
+      }
+      return (await this._conn.requestGet<CheckDeployStatusRest>(url)).deployResult;
+    } else {
+      return this._invoke(
+        'checkDeployStatus',
+        {
+          asyncProcessId,
+          includeDetails,
+        },
+        ApiSchemas.DeployResult,
+      );
+    }
   }
 
  async cancelDeploy(id: string): Promise<CancelDeployResult>{

--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -454,7 +454,7 @@ export class MetadataApi<S extends Schema> {
 
   /**
    * Checks the status of declarative metadata call deploy(), using either
-   * SOAP or REST APIs.  SOAP is the default.
+   * SOAP or REST APIs. SOAP is the default.
    */
   async checkDeployStatus(
     asyncProcessId: string,

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -239,6 +239,10 @@ if (isNodeJS()) {
       const result = await conn.metadata.deployRest(zipBuffer);
       assert.ok(result.id);
 
+      const sleep500ms = async () => {
+        return new Promise(resolve => setTimeout(resolve, 500));
+      }
+
       let count = 0;
       let deployResult!: DeployResult;
       while(count < 50) {
@@ -247,6 +251,7 @@ if (isNodeJS()) {
         if (deployResult.done === true) {
           break;
         }
+        await sleep500ms();
       }
 
       assert.ok(deployResult);

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -230,6 +230,26 @@ if (isNodeJS()) {
       );
       assert.ok(result.numberTestsCompleted === 1);
     });
+
+    it('should check deploy status', async () => {
+      const zipBuffer = await fs.promises.readFile(
+        path.join(__dirname, '/data/MyPackage.zip'),
+      );
+      const result = await conn.metadata
+        .deployRest(zipBuffer, {
+          testLevel: 'RunSpecifiedTests',
+          runTests: ['MyApexTriggerTest'],
+        });
+      assert.ok(result.id);
+      const deployResult = await conn.metadata.checkDeployStatus(result.id, true, true);
+      assert.ok(deployResult.done === true);
+      assert.ok(deployResult.success === true);
+      assert.ok(deployResult.status === 'Succeeded');
+      assert.ok(deployResult.numberComponentErrors === 0);
+      assert.ok(
+        deployResult.numberComponentsDeployed === deployResult.numberComponentsTotal,
+      );
+    });
   });
 }
 

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -6,6 +6,7 @@ import ConnectionManager from './helper/connection-manager';
 import config from './config';
 import { isObject, isString } from './util';
 import { isNodeJS } from './helper/env';
+import { DeployResult } from 'jsforce/lib/api/metadata';
 
 const connMgr = new ConnectionManager(config);
 const conn = connMgr.createConnection();
@@ -235,13 +236,20 @@ if (isNodeJS()) {
       const zipBuffer = await fs.promises.readFile(
         path.join(__dirname, '/data/MyPackage.zip'),
       );
-      const result = await conn.metadata
-        .deployRest(zipBuffer, {
-          testLevel: 'RunSpecifiedTests',
-          runTests: ['MyApexTriggerTest'],
-        });
+      const result = await conn.metadata.deployRest(zipBuffer);
       assert.ok(result.id);
-      const deployResult = await conn.metadata.checkDeployStatus(result.id, true, true);
+
+      let count = 0;
+      let deployResult!: DeployResult;
+      while(count < 50) {
+        count++;
+        deployResult = await conn.metadata.checkDeployStatus(result.id, true, true);
+        if (deployResult.done === true) {
+          break;
+        }
+      }
+
+      assert.ok(deployResult);
       assert.ok(deployResult.done === true);
       assert.ok(deployResult.success === true);
       assert.ok(deployResult.status === 'Succeeded');


### PR DESCRIPTION
`metadata.checkDeployStatus()` now supports an optional `rest` param to call the deploy status REST endpoint rather than always using SOAP.  SOAP is still the default if the `rest` param is not passed.  Added a test for this code path as well.

@W-18012955@