### PR TITLE
feat: allow skipping template eval on query update W-18268091

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -188,6 +188,10 @@ export type QueryUpdateOptions = {
   allowBulk?: boolean;
   bulkThreshold?: number;
   bulkApiVersion?: BulkApiVersion;
+  /**
+   * Skip record template evaluation.
+   */
+  skipRecordTemplateEval?: boolean;
 };
 
 /**
@@ -1038,7 +1042,7 @@ export class Query<
     const updateStream =
       typeof mapping === 'function'
         ? RecordStream.map(mapping)
-        : RecordStream.recordMapStream(mapping);
+        : RecordStream.recordMapStream(mapping, options.skipRecordTemplateEval);
     // Set the threshold number to pass to bulk API
     const thresholdNum =
       options.allowBulk === false


### PR DESCRIPTION
Fixes: https://github.com/jsforce/jsforce/issues/1676

When doing `sobject().find().update()`, jsforce evaluates the update fields for possible record templates (jsforce syntax sugar for easy string replacement), for the mentioned use-case in #1676 we now allow to skip it via a new boolean option.

Tests added by Cursor 🪄 (needed some polish but were almost perfect).

@W-18268091@