### PR TITLE
feat: adds language attribute to the scratch org's definition file

### DIFF
--- a/test/org-setup/project-scratch-def.json
+++ b/test/org-setup/project-scratch-def.json
@@ -10,5 +10,6 @@
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }
-  }
+  },
+  "language": "en_US"
 }


### PR DESCRIPTION
This small patch adds the `language` attribute to the scratch org's definition file so that developers that wish to contribute to the project all work on the same language for the org. 

Reason: some unit tests require an exact match to messages provided by the platform's API in English.