### PR TITLE
fix(SOAP): block connections using JWT tokens W-18585436

### DIFF
--- a/src/soap.ts
+++ b/src/soap.ts
@@ -213,7 +213,7 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
     if (this._conn.accessToken && isJWTToken(this._conn.accessToken)) {
       // We need to block SOAP requests with JWT tokens because the response is:
       // statusCode=500 | body="INVALID_SESSION_ID" (xml), which triggers session refresh and enters in an infinite loop
-      throw new Error('SOAP API does not support JWT-based access tokens.')
+      throw new Error('SOAP API does not support JWT-based access tokens. You must disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App')
     }
     this._endpointUrl = options.endpointUrl;
     this._xmlns = options.xmlns || 'urn:partner.soap.sforce.com';

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -13,6 +13,7 @@ import {
 } from './types';
 import { isMapObject, isObject } from './util/function';
 import { getBodySize } from './util/get-body-size';
+import { isJWTToken } from './util/jwt';
 
 /**
  *
@@ -209,6 +210,11 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
 
   constructor(conn: Connection<S>, options: SOAPOptions) {
     super(conn, options);
+    if (this._conn.accessToken && isJWTToken(this._conn.accessToken)) {
+      // We need to block SOAP requests with JWT tokens because the response is:
+      // statusCode=500 | body="INVALID_SESSION_ID" (xml), which triggers session refresh and enters in an infinite loop
+      throw new Error('SOAP API does not support JWT-based access tokens.')
+    }
     this._endpointUrl = options.endpointUrl;
     this._xmlns = options.xmlns || 'urn:partner.soap.sforce.com';
   }

--- a/src/util/jwt.ts
+++ b/src/util/jwt.ts
@@ -1,0 +1,18 @@
+/**
+ * Checks if a given access token is a JWT.
+ *
+ * @param {string} accessToken - The access token to check
+ * @returns {boolean} True if the token is a valid JWT token, false otherwise.
+ */
+export function isJWTToken(accessToken: string): boolean {
+  const parts = accessToken.split('.');
+  if (parts.length !== 3) return false;
+
+  const header = parts[0];
+  try {
+    JSON.parse(atob(header));
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/test/jwt-util.test.ts
+++ b/test/jwt-util.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert';
+import { isJWTToken } from '../src/util/jwt';
+
+describe('JWT Utils', () => {
+  describe('isJWTToken', () => {
+    it('should return true for valid JWT tokens', () => {
+      const validJWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      assert.strictEqual(isJWTToken(validJWT), true);
+    });
+
+    it('should return false for non-JWT tokens', () => {
+      const nonJWT = '00Dxx0000001gT4!AQcAQH0dTHZfz8SzZpNVJtNKfCzW8YZJKg6b8PGp_5jWkRZKt6RqoVx1HdGQp6T6kCFJ8gB8QPGhQx9qysE6vq3Zc';
+      assert.strictEqual(isJWTToken(nonJWT), false);
+    });
+
+    it('should return false for malformed JWT tokens', () => {
+      const malformedJWT = 'not.a.jwt.token';
+      assert.strictEqual(isJWTToken(malformedJWT), false);
+    });
+
+    it('should return false for empty string', () => {
+      assert.strictEqual(isJWTToken(''), false);
+    });
+
+    it('should return false for tokens with invalid base64 in header', () => {
+      const invalidBase64JWT = 'invalid.base64.signature';
+      assert.strictEqual(isJWTToken(invalidBase64JWT), false);
+    });
+
+    it('should return false for tokens with invalid JSON in header', () => {
+      const invalidJSONJWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      assert.strictEqual(isJWTToken(invalidJSONJWT), false);
+    });
+  });
+}); 


### PR DESCRIPTION
Update the SOAP module to throw if the provided `connection` is using a JWT-based access tokens.

Due to how session-refresh works and SOAP APIs not support JWT tokens, trying to use them makes jsforce enter into an infinite loop trying to fetch a valid token.

### QA instructions
1. checkout this PR and build jsforce-node: `npm i && npm run jsforce-node:dev && npm run build:node:cjs`
2. link it into plugin-deploy-retrieve or plugin-org: `yarn link @jsforce/jsforce-node`
3. auth to an org using a connected app with JWT-access tokens enabled.
4. run a command that does a SOAP request like `project deploy start`/`org list metadata`:

without this PR, jsforce enters the infinite loop (set `JSFORCE_LOG_LEVEL=DEBUG` to debug logs).
Now any code trying to do SOAP requests will fail like this:

![Screenshot 2025-05-21 at 13 25 16](https://github.com/user-attachments/assets/ad12baf4-703b-4924-8f15-4a55e72ae01a)

@W-18585436@