### PR TITLE
W-19055021 fix: no setting content-length in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",


### PR DESCRIPTION
don't set content-length in browser.  The browser automatically does it and trying to mess with it violates browser security rules.

request.ts:180 Refused to set unsafe header "content-length"
eval	@	request.ts:180
_callee2$	@	request-helper.ts:103
executeWithTimeout	@	request-helper.ts:88
_callee4$	@	request.ts:175
Promise.then		
startXmlHttpRequest	@	request.ts:162
request	@	request.ts:271
eval	@	transport.ts:51
create	@	promise.ts:24
httpRequest	@	transport.ts:49
_callee$	@	http-api.ts:98
eval	@	http-api.ts:157
create	@	promise.ts:24
request	@	http-api.ts:65
_callee$	@	soap.ts:231
invoke	@	soap.ts:225
_callee$	@	metadata.ts:116
_invoke	@	metadata.ts:107
describe	@	metadata.ts:283