### PR TITLE
fix: set default request timeout W-18649787

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.9.3",
+      "version": "3.9.4",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/src/request.ts
+++ b/src/request.ts
@@ -179,8 +179,13 @@ async function startFetchRequest(
 
   let res: Response;
 
+  // Timeout after 60s without a response
+  //
+  // node-fetch's default timeout is 0 and jsforce consumers can't set this when calling `Connection` methods so we set a long default at the fetch wrapper level.
+  const fetchTimeout = options.timeout ?? 60_000
+
   try {
-    res = await executeWithTimeout(fetchWithRetries, options.timeout, () =>
+    res = await executeWithTimeout(fetchWithRetries, fetchTimeout, () =>
       controller.abort(),
     );
   } catch (err) {

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -251,7 +251,7 @@ describe('HTTP API', () => {
     it('throws after 5 seconds timeout', async () => {
       nock(loginUrl)
         .get('/services/data/v59.0')
-        .delay(7000) // Delay response by 21 seconds to exceed timeout
+        .delay(7000) // Delay response by 7 seconds to exceed timeout
         .reply(200, { success: true });
 
       const { err } = await fetch(

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -247,6 +247,26 @@ describe('HTTP API', () => {
       );
       assert.ok(retryCounter === 0);
     });
+
+    it('throws after 5 seconds timeout', async () => {
+      nock(loginUrl)
+        .get('/services/data/v59.0')
+        .delay(7000) // Delay response by 21 seconds to exceed timeout
+        .reply(200, { success: true });
+
+      const { err } = await fetch(
+        {
+          method: 'GET',
+          url: `${loginUrl}/services/data/v59.0`,
+        },
+        {
+          timeout: 5000, // 5 second timeout
+        },
+      );
+
+      assert.ok(err instanceof Error);
+      assert.ok(err.name === 'AbortError' || err.message.includes('aborted'));
+    });
   });
 
   describe('headers', () => {
@@ -588,6 +608,8 @@ See \`error.data\` for the full html response.`,
         },
       );
     })
+
+
   });
 });
 


### PR DESCRIPTION
Adds a default timeout (60 seconds) in the node-fetch wrapper to prevent hanging requests.

node-fetch v2 default is `0`:
https://github.com/node-fetch/node-fetch/tree/2.x?tab=readme-ov-file#options

### Context
We have a customer that is able to start a metadata retrieve via `sf project retrieve start` and get a few retrieve status checks SOAP calls done but then hangs at `calling metadata.checkRetrieveStatus` for 33 minutes (CLI default wait time)
```
[12:52:40.164] DEBUG (sf:MetadataApiRetrieve): MDAPI status update: InProgress
[12:52:40.665] DEBUG (sf:MetadataApiRetrieve): getting connection instance
[12:52:40.665] DEBUG (sf:MetadataApiRetrieve): calling metadata.checkRetrieveStatus
[12:52:40.734] DEBUG (sf:MetadataApiRetrieve): successfully called metadata.checkRetrieveStatus
[12:52:40.734] DEBUG (sf:MetadataApiRetrieve): status.status: InProgress
[12:52:40.734] DEBUG (sf:MetadataApiRetrieve): status.done: false
[12:52:40.734] DEBUG (sf:MetadataApiRetrieve): status.success: false
[12:52:40.734] DEBUG (sf:MetadataApiRetrieve): emitting update event
[12:52:40.735] DEBUG (sf:MetadataApiRetrieve): emited update event successfully
[12:52:40.735] DEBUG (sf:MetadataApiRetrieve): MDAPI status update: InProgress
[12:52:41.235] DEBUG (sf:MetadataApiRetrieve): getting connection instance
[12:52:41.235] DEBUG (sf:MetadataApiRetrieve): calling metadata.checkRetrieveStatus
▶ Waiting for the org to respond…

```

the client (jsforce) should not have hang like that for so long.



@W-18649787@