### PR TITLE
fix(request): support https-proxy-agent v7 named export (retain v5 compat)

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
 import fetch, { Response, RequestInit, FetchError } from 'node-fetch';
-import createHttpsProxyAgent from 'https-proxy-agent';
+import * as HttpsProxyAgentNS from 'https-proxy-agent';
 import {
   createHttpRequestHandlerStreams,
   executeWithTimeout,
@@ -37,7 +37,10 @@ async function startFetchRequest(
 ) {
   const logger = getLogger('fetch');
   const { httpProxy, followRedirect } = options;
-  const agent = httpProxy ? createHttpsProxyAgent(httpProxy) : undefined;
+  const HttpsProxyAgentCtor: any =
+  (HttpsProxyAgentNS as any).HttpsProxyAgent ??
+  (HttpsProxyAgentNS as any).default;
+  const agent = httpProxy ? new HttpsProxyAgentCtor(httpProxy) : undefined;
   const { url, body, ...rrequest } = request;
   const controller = new AbortController();
 


### PR DESCRIPTION
### Summary
JSforce throws at runtime when the dependency tree resolves https-proxy-agent@7:
```
TypeError: (0, https_proxy_agent_1.default) is not a function
```

v7 switched to a named class export (HttpsProxyAgent), while the current code assumes a default export. This PR adds a tiny compatibility shim to support both v5 (default export) and v7 (named export).

### Change
```
// before
import createHttpsProxyAgent from 'https-proxy-agent';
const agent = httpProxy ? createHttpsProxyAgent(httpProxy) : undefined;

// after (compat for v5 & v7)
import * as HttpsProxyAgentNS from 'https-proxy-agent';
const HttpsProxyAgentCtor: any =
  (HttpsProxyAgentNS as any).HttpsProxyAgent ??
  (HttpsProxyAgentNS as any).default;
const agent = httpProxy ? new HttpsProxyAgentCtor(httpProxy) : undefined;
```

### Why

- https-proxy-agent@7 is ESM-only with named exports; the default is undefined.
- Backwards compatible: still works if a consumer has v5 in the tree.

### Environment

- JSforce: 3.10.5 (issue reproduced on npm release)
- Patched in: commit 7b74bbf (branch fix/https-proxy-agent-v7)
- Runtime: Bun v1.2.21 (also tested Node v22 if applicable)
- Package manager: Bun (bun install)
- https-proxy-agent: 7.x

Issue
Fixes #1758