### PR TITLE
feat: allow to disable exponential retry back-off

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*, latest]
+        # TODO(cristian): temporally disable latest (node v25), sf CLI fails with it
+        # node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,11 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
-import fetch, { Response, RequestInit, FetchError, AbortError } from 'node-fetch';
+import fetch, {
+  Response,
+  RequestInit,
+  FetchError,
+  AbortError,
+} from 'node-fetch';
 import createHttpsProxyAgent from 'https-proxy-agent';
 import {
   createHttpRequestHandlerStreams,
@@ -43,30 +48,43 @@ async function startFetchRequest(
 
   let retryCount = 0;
 
-  const retryOpts: Required<HttpRequestOptions['retry']> = {
-    statusCodes: options.retry?.statusCodes ?? [420, 429, 500, 502, 503, 504],
-    maxRetries: options.retry?.maxRetries ?? 5,
-    minTimeout: options.retry?.minTimeout ?? 500,
-    timeoutFactor: options.retry?.timeoutFactor ?? 2,
-    errorCodes: options.retry?.errorCodes ?? [
-      'ECONNRESET',
-      'ECONNREFUSED',
-      'ENOTFOUND',
-      'ENETDOWN',
-      'ENETUNREACH',
-      'EHOSTDOWN',
-      'UND_ERR_SOCKET',
-      'ETIMEDOUT',
-      'EPIPE',
-    ],
-    methods: options.retry?.methods ?? [
-      'GET',
-      'PUT',
-      'HEAD',
-      'OPTIONS',
-      'DELETE',
-    ],
-  };
+  const retryOpts: Required<HttpRequestOptions['retry']> =
+    typeof process !== 'undefined' &&
+    process.env?.JSFORCE_DISABLE_HTTP_RETRY_BACKOFF
+      ? {
+          statusCodes: [],
+          maxRetries: 0,
+          minTimeout: 500,
+          timeoutFactor: 2,
+          errorCodes: [],
+          methods: [],
+        }
+      : {
+          statusCodes: options.retry?.statusCodes ?? [
+            420, 429, 500, 502, 503, 504,
+          ],
+          maxRetries: options.retry?.maxRetries ?? 5,
+          minTimeout: options.retry?.minTimeout ?? 500,
+          timeoutFactor: options.retry?.timeoutFactor ?? 2,
+          errorCodes: options.retry?.errorCodes ?? [
+            'ECONNRESET',
+            'ECONNREFUSED',
+            'ENOTFOUND',
+            'ENETDOWN',
+            'ENETUNREACH',
+            'EHOSTDOWN',
+            'UND_ERR_SOCKET',
+            'ETIMEDOUT',
+            'EPIPE',
+          ],
+          methods: options.retry?.methods ?? [
+            'GET',
+            'PUT',
+            'HEAD',
+            'OPTIONS',
+            'DELETE',
+          ],
+        };
 
   const shouldRetryRequest = (
     maxRetry: number,
@@ -77,7 +95,7 @@ async function startFetchRequest(
     if (resOrErr instanceof Response) {
       if (retryOpts.statusCodes.includes(resOrErr.status)) {
         if (maxRetry === retryCount) {
-          return false
+          return false;
         } else {
           return true;
         }
@@ -190,7 +208,8 @@ async function startFetchRequest(
     );
   } catch (err) {
     if (err instanceof AbortError) {
-      (err as Error).message += ' Request was aborted due to timeout of 10 minutes.';
+      (err as Error).message +=
+        ' Request was aborted after 30 minutes (timeout)';
     }
     emitter.emit('error', err);
     return;

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -43,23 +43,32 @@ describe('HTTP API', () => {
       nock(loginUrl)
         .get('/services/data/v59.0')
         .times(4)
-        .reply(429, JSON.stringify({
-          errorCode: 'INTERNAL_SERVER_ERROR',
-          message: 'Invalid AiEvaluation identifier'
-        }))
+        .reply(
+          429,
+          JSON.stringify({
+            errorCode: 'INTERNAL_SERVER_ERROR',
+            message: 'Invalid AiEvaluation identifier',
+          }),
+        );
 
-      const { retryCounter,res } = await fetch({
-        method: 'GET',
-        url: `${loginUrl}/services/data/v59.0`,
-      }, {
+      const { retryCounter, res } = await fetch(
+        {
+          method: 'GET',
+          url: `${loginUrl}/services/data/v59.0`,
+        },
+        {
           retry: {
-            maxRetries: 3
-          }
-        });
-      assert.ok('body' in res)
-      assert.equal(res.body, '{"errorCode":"INTERNAL_SERVER_ERROR","message":"Invalid AiEvaluation identifier"}')
+            maxRetries: 3,
+          },
+        },
+      );
+      assert.ok('body' in res);
+      assert.equal(
+        res.body,
+        '{"errorCode":"INTERNAL_SERVER_ERROR","message":"Invalid AiEvaluation identifier"}',
+      );
       assert.ok(retryCounter === 3);
-    })
+    });
 
     it('retries on specified status code', async () => {
       const attempts = 2;
@@ -267,6 +276,44 @@ describe('HTTP API', () => {
       assert.ok(err instanceof Error);
       assert.ok(err.name === 'AbortError' || err.message.includes('aborted'));
     });
+
+    it('disables retries when JSFORCE_DISABLE_HTTP_RETRY_BACKOFF is set', async () => {
+      const originalEnv = process.env.JSFORCE_DISABLE_HTTP_RETRY_BACKOFF;
+      process.env.JSFORCE_DISABLE_HTTP_RETRY_BACKOFF = 'true';
+
+      try {
+        nock(loginUrl)
+          .get('/services/data/v59.0')
+          .times(3)
+          .reply(
+            429,
+            JSON.stringify({
+              errorCode: 'INTERNAL_SERVER_ERROR',
+              message: 'Invalid AiEvaluation identifier',
+            }),
+          );
+
+        const { retryCounter, res } = await fetch({
+          method: 'GET',
+          url: `${loginUrl}/services/data/v59.0`,
+        });
+
+        // Should not retry when environment variable is set
+        assert.ok(retryCounter === 0);
+        assert.ok('body' in res);
+        assert.equal(
+          res.body,
+          '{"errorCode":"INTERNAL_SERVER_ERROR","message":"Invalid AiEvaluation identifier"}',
+        );
+      } finally {
+        // Restore original environment variable
+        if (originalEnv === undefined) {
+          delete process.env.JSFORCE_DISABLE_HTTP_RETRY_BACKOFF;
+        } else {
+          process.env.JSFORCE_DISABLE_HTTP_RETRY_BACKOFF = originalEnv;
+        }
+      }
+    });
   });
 
   describe('headers', () => {
@@ -452,7 +499,7 @@ describe('HTTP API', () => {
         {
           errorCode: missingRequiredFieldErr[0].errorCode,
           message: missingRequiredFieldErr[0].message,
-          content: {...missingRequiredFieldErr[0]}
+          content: { ...missingRequiredFieldErr[0] },
         },
       );
     });
@@ -583,7 +630,7 @@ See \`error.data\` for the full html response.`,
           message: 'no 123 phone',
           errorCode: 'FIELD_CUSTOM_VALIDATION_EXCEPTION',
           fields: [],
-        }
+        },
       ];
 
       nock(loginUrl)
@@ -607,9 +654,7 @@ See \`error.data\` for the full html response.`,
           content: errors,
         },
       );
-    })
-
-
+    });
   });
 });
 
@@ -720,8 +765,7 @@ describe('SOAP API', () => {
         loginUrl,
       });
 
-      const passwordExpiredXml =
-`<?xml version="1.0" encoding="UTF-8"?>
+      const passwordExpiredXml = `<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope
 	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
 	xmlns="urn:partner.soap.sforce.com"
@@ -733,21 +777,23 @@ describe('SOAP API', () => {
 			</result>
 		</loginResponse>
 	</soapenv:Body>
-</soapenv:Envelope>`
+</soapenv:Envelope>`;
 
       nock(loginUrl)
         .post('/services/Soap/u/50.0')
         .reply(200, passwordExpiredXml);
 
-
-      await assert.rejects(async () => {
-        // SOAP login requests will return 200 even with an expired password:
-        // https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login_loginresult.htm?q=passwordExpired
-        await conn.login('username','password')
-      }, {
-          message: 'Unable to login because the used password has expired.'
-        })
-    })
+      await assert.rejects(
+        async () => {
+          // SOAP login requests will return 200 even with an expired password:
+          // https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login_loginresult.htm?q=passwordExpired
+          await conn.login('username', 'password');
+        },
+        {
+          message: 'Unable to login because the used password has expired.',
+        },
+      );
+    });
 
     it('handle `Content-Length` header after session refresh', async () => {
       const conn = new Connection({


### PR DESCRIPTION
Allow disabling HTTP retries by setting the new env var `JSFORCE_DISABLE_HTTP_RETRY_BACKOFF=true`.

This env var disables retries at the process level, we still can't allow to disable retries per `Connection` instance due to how methods call the request handler internally.

Fixes: https://github.com/jsforce/jsforce/issues/1643