### PR TITLE
chore: update poll method with checkRetrieveStatus-W-20678837

### DIFF
--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -528,7 +528,7 @@ export class AsyncResultLocator<
   async check() {
     const result = await this._promise;
     this._id = result.id;
-    return this._meta.checkRetrieveStatus(result.id);
+    return this._meta.checkStatus(result.id);
   }
 
   /**

--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -528,7 +528,7 @@ export class AsyncResultLocator<
   async check() {
     const result = await this._promise;
     this._id = result.id;
-    return this._meta.checkStatus(result.id);
+    return this._meta.checkRetrieveStatus(result.id);
   }
 
   /**


### PR DESCRIPTION
replace the `checkStatus` poll method when retrieve and deploy.
`Retrieve()` calls directly to `checkRetrieveStatus` and `Deploy()` calls directly to `checkDeployStatus()`.

checkStatus(): deprecated
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_checkstatus.htm
