### PR TITLE
fix(http): reduce buffer allocations when reading responses W-18649787

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,9 +114,13 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+      
+      - name: Run Perf tests
+        run: npm run test:node:perf
 
       - name: Install sf CLI
-        run: npm install --global @salesforce/cli
+        id: install-sf-cli
+        run: npm install --global @salesforce/cli@nightly
 
       - name: Setup scratch org
         env:
@@ -139,7 +143,7 @@ jobs:
           npm run test:node
 
       - name: Delete scratch org
-        if: always()
+        if: always() && steps.install-sf-cli.outcome == 'success'
         run: sf org delete scratch --target-org jsforce-test-org --no-prompt
 
   salesforce-cli-external-nuts:
@@ -184,7 +188,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run Perf tests
+        run: npm run test:node:perf
+
       - name: Install sf CLI
+        id: install-sf-cli
         run: npm install --global @salesforce/cli@nightly
 
       - name: Setup scratch org
@@ -208,5 +216,5 @@ jobs:
           npm run test:node
 
       - name: Delete scratch org
-        if: always()
+        if: always() && steps.install-sf-cli.outcome == 'success'
         run: sf org delete scratch --target-org jsforce-test-org --no-prompt

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
     files: ['dist/jsforce.js', 'test/**/!(*http-api).test.ts'],
 
     // list of files / patterns to exclude
-    exclude: [],
+    exclude: ['test/perf/**/*.ts'],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Shinichi Tomita <shinichi.tomita@gmail.com>",
-  "name": "@jsforce/jsforce-node",
+  "name": "jsforce",
   "description": "Salesforce API Library for JavaScript",
   "keywords": [
     "salesforce",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Shinichi Tomita <shinichi.tomita@gmail.com>",
-  "name": "jsforce",
+  "name": "@jsforce/jsforce-node",
   "description": "Salesforce API Library for JavaScript",
   "keywords": [
     "salesforce",
@@ -108,6 +108,16 @@
       ],
       "output": []
     },
+    "test:node:perf": {
+      "command": "jest test/perf --config {}",
+      "dependencies": [
+        "build:node:cjs"
+      ],
+      "files": [
+        "test/perf/**/*.test.ts"
+      ],
+      "output": []
+    },
     "test:browser": {
       "command": "karma start",
       "dependencies": [
@@ -178,6 +188,7 @@
     "lint": "wireit",
     "test": "wireit",
     "test:node": "wireit",
+    "test:node:perf": "wireit",
     "test:browser": "wireit",
     "test:browser-ci": "wireit",
     "test:browser-ci:retry": "wireit",

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -41,7 +41,7 @@ if (
 }
 
 const orgDefinitionFile = join('test', 'org-setup', 'project-scratch-def.json');
-await $`sf org create scratch --definition-file ${orgDefinitionFile} --wait 20 --duration-days 1 --alias jsforce-test-org --json`;
+await $`sf org create scratch --definition-file ${orgDefinitionFile} --wait 20 --duration-days 1 --alias jsforce-test-org --no-track-source --json`;
 
 await $`sf org generate password --target-org jsforce-test-org --json`;
 

--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -2,6 +2,9 @@ import { PassThrough } from 'stream';
 import { concatStreamsAsDuplex, readAll } from './util/stream';
 import { HttpRequest, HttpRequestOptions, HttpResponse } from './types';
 import FormData from 'form-data';
+import { getLogger } from './util/logger';
+
+const logger = getLogger('request-helper');
 
 /**
  *
@@ -26,7 +29,16 @@ export function createHttpRequestHandlerStreams(
   }
   duplex.on('response', async (res) => {
     if (duplex.listenerCount('complete') > 0) {
+      logger.debug('Processing response');
+      const start = Date.now();
+
       const resBody = await readAll(duplex, options.encoding);
+
+      logger.debug(
+        `Response body read: ${(resBody.length / 1024 / 1024).toFixed(1)}MB ` +
+          `in ${Date.now() - start}ms`,
+      );
+
       duplex.emit('complete', {
         ...res,
         body: resBody,

--- a/test/perf/stream-performance.test.ts
+++ b/test/perf/stream-performance.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Performance regression tests for readAll in src/util/stream.ts
+ *
+ * These tests ensure that performance is maintained and detect any
+ * regressions that might be introduced by future changes.
+ *
+ * Run with:
+ *   npx jest test/stream-performance.test.ts --verbose
+ *
+ * The baselines serve as "snapshots" of expected performance. If tests fail:
+ * 1. A regression was introduced (fix the code), OR
+ * 2. Hardware/environment is significantly different (adjust baselines)
+ */
+import { Readable } from 'node:stream';
+import { readAll } from '../../src/util/stream';
+
+/**
+ * Performance baselines - these serve as "snapshots" of expected performance.
+ *
+ * These values are intentionally generous to account for CI variability.
+ */
+const PERFORMANCE_BASELINES = {
+  // Maximum time allowed for readAll to process data (ms per MB)
+  maxMsPerMB: {
+    small: 10, // 1-5MB: allow 10ms per MB
+    medium: 5, // 5-50MB: allow 5ms per MB
+    large: 3, // 50MB+: allow 3ms per MB
+  } as Record<string, number>,
+
+  // Maximum scaling factor when data size increases 4x (5MB → 20MB)
+  // O(n) should be ~4x, O(n²) would be ~16x
+  // We use 8x as threshold to catch quadratic regressions
+  maxScalingFactor: 8,
+};
+
+/**
+ * Creates a readable stream that delivers data in chunks (simulates network).
+ */
+function createChunkedStream(
+  data: Buffer,
+  chunkSize: number = 64 * 1024,
+): Readable {
+  let offset = 0;
+
+  return new Readable({
+    read() {
+      setImmediate(() => {
+        if (offset >= data.length) {
+          this.push(null);
+          return;
+        }
+
+        const end = Math.min(offset + chunkSize, data.length);
+        const chunk = data.subarray(offset, end);
+        offset = end;
+        this.push(chunk);
+      });
+    },
+  });
+}
+
+/**
+ * Measures time to process data through readAll.
+ */
+async function measureReadAll(
+  sizeMB: number,
+): Promise<{ timeMs: number; resultLength: number }> {
+  const data = Buffer.alloc(sizeMB * 1024 * 1024, 'x');
+  const stream = createChunkedStream(data);
+
+  const startTime = performance.now();
+  const result = await readAll(stream);
+  const endTime = performance.now();
+
+  return {
+    timeMs: endTime - startTime,
+    resultLength: result.length,
+  };
+}
+
+// Collect metrics for summary output
+const collectedMetrics: {
+  sizeMB: number;
+  timeMs: number;
+  msPerMB: number;
+}[] = [];
+
+describe('readAll performance regression tests', () => {
+  // Test 1: Absolute performance thresholds
+  describe('should meet performance baselines', () => {
+    const testCases: { sizeMB: number; category: string }[] = [
+      { sizeMB: 1, category: 'small' },
+      { sizeMB: 5, category: 'medium' },
+      { sizeMB: 20, category: 'medium' },
+    ];
+
+    for (const { sizeMB, category } of testCases) {
+      const maxMsPerMB = PERFORMANCE_BASELINES.maxMsPerMB[category];
+
+      it(`should process ${sizeMB}MB within ${maxMsPerMB}ms/MB`, async () => {
+        const { timeMs, resultLength } = await measureReadAll(sizeMB);
+        const msPerMB = timeMs / sizeMB;
+
+        // Verify data integrity
+        expect(resultLength).toBe(sizeMB * 1024 * 1024);
+
+        // Log metrics
+        console.log(
+          `  ${sizeMB}MB: ${timeMs.toFixed(0)}ms (${msPerMB.toFixed(1)}ms/MB)`,
+        );
+        collectedMetrics.push({ sizeMB, timeMs, msPerMB });
+
+        // Performance assertion
+        expect(msPerMB).toBeLessThanOrEqual(maxMsPerMB);
+      });
+    }
+  });
+
+  // Test 2: Scaling characteristics - detects O(n²) regressions
+  describe('should scale linearly (O(n))', () => {
+    it('should have scaling factor < 8x when data increases 4x (5MB → 20MB)', async () => {
+      const result5MB = await measureReadAll(5);
+      const result20MB = await measureReadAll(20);
+
+      // For O(n): 20MB should take ~4x as long as 5MB
+      // For O(n²): 20MB would take ~16x as long as 5MB
+      const scalingFactor = result20MB.timeMs / result5MB.timeMs;
+
+      console.log(
+        `  5MB: ${result5MB.timeMs.toFixed(0)}ms, ` +
+          `20MB: ${result20MB.timeMs.toFixed(0)}ms, ` +
+          `Scaling factor: ${scalingFactor.toFixed(1)}x`,
+      );
+
+      // Should be closer to 4x than 16x - this catches O(n²) regressions
+      expect(scalingFactor).toBeLessThan(
+        PERFORMANCE_BASELINES.maxScalingFactor,
+      );
+    });
+  });
+
+  // Output summary after all tests
+  afterAll(() => {
+    console.log('\n=== Performance Metrics Summary ===');
+    console.log(JSON.stringify(collectedMetrics, null, 2));
+    console.log('===================================\n');
+  });
+});


### PR DESCRIPTION
This PR updates the `MemoryWriteStream` writable that's used to process an HTTP response body.

### Context

We got a report from a customer where a retrieve of static resources via `sf` was constantly hanging in the middle of the polling checks, last log lines printed:
```
DEBUG   [http-api]  missing 'content-length' header, setting it to: 708
DEBUG   [http-api]  <request> method=POST, url=https://dreamhouse-lala.salesforce.com/services/Soap/m/63.0
DEBUG   [http-api]  elapsed time: 75 msec
DEBUG   [http-api]  <response> status=200, url=https://dreamhouse-lala.salesforce.com/services/Soap/m/63.0
DEBUG   [http-api]  missing 'content-length' header, setting it to: 708
DEBUG   [http-api]  <request> method=POST, url=https://dreamhouse-lala.salesforce.com/services/Soap/m/63.0
DEBUG   [http-api]  elapsed time: 1358512 msec
DEBUG   [http-api]  <response> status=200, url=https://dreamhouse-lala.salesforce.com/services/Soap/m/63.0
```

which shows the request promise in L107 was never resolved:
https://github.com/jsforce/jsforce/blob/6c6cc289950a878b8f5f2a81160ad23ea48b7190/src/http-api.ts#L94-L107

**IMPORTANT:**
At this point the CLI didn't thrown an error or exited, the process would just hang indefinitely.

The retrieve polling involves calling `checkRetrieveStatus` multiple times with until it's done, with the last response including the base64-encoded zip of metadata.
 

### Bug
The behavior of `checkRetrieveStatus` and the logs showed that last response with the zip file was causing jsforce to hang (the customer who reported this was on a low-resources windows vm).

code path of the API call:
```
checkRetrieveStatus()
    → _invoke()
    → SOAP.invoke()
    → HttpApi.request()
    → Transport.httpRequest()
    → node-fetch
    → res.body.pipe(output)
    → readAll() with MemoryWriteStream
    → parseXML() with xml2js
```

After debugging it with the payload we found the issue was in the way the `MemoryWriteStream` writer was processing the chunks, calling `Buffer.concat` 1 time per chunk to store the whole response in a buffer was constantly copying/destroying buffers which caused node's garbage collector to froze the process trying to clean up memory.

We verified the fix with the customer and got the retrieve working in ~3minutes.


### Testing
There's a new perf test to measure `readAll` performance, see the how it failed in the 1st commit (only added the test without the writer fixes).

<img width="1845" height="1092" alt="Screenshot 2026-01-15 at 16 30 11" src="https://github.com/user-attachments/assets/cf9c6192-9abc-4bd7-82db-472e765e7cc4" />


@W-18649787@
