### PR TITLE
fix(soap): allow JWT access tokens on API v67.0+ W-22352136

### DIFF
--- a/src/soap.ts
+++ b/src/soap.ts
@@ -210,11 +210,12 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
 
   constructor(conn: Connection<S>, options: SOAPOptions) {
     super(conn, options);
-    if (this._conn.accessToken && isJWTToken(this._conn.accessToken)) {
-      // We need to block SOAP requests with JWT tokens because the response is:
-      // statusCode=500 | body="INVALID_SESSION_ID" (xml), which triggers session refresh and enters in an infinite loop
+    if (this._conn.accessToken && isJWTToken(this._conn.accessToken) && !this._conn._ensureVersion(67)) {
+      // JWT-based access tokens are only supported by the SOAP API starting in API version 67.0.
+      // On older versions the response is statusCode=500 | body="INVALID_SESSION_ID" (xml),
+      // which triggers session refresh and enters an infinite loop.
       throw new Error(
-        'SOAP API does not support JWT-based access tokens. You must disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App',
+        'SOAP API does not support JWT-based access tokens prior to API version 67.0. Either upgrade the API version to 67.0 or later, or disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App',
       );
     }
     this._endpointUrl = options.endpointUrl;

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -858,6 +858,76 @@ describe('SOAP API', () => {
     });
   });
 
+  describe('JWT access token', () => {
+    const jwtToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+
+    it('throws when API version is below 67.0', () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: jwtToken,
+        version: '66.0',
+      });
+
+      assert.throws(
+        () =>
+          new SOAP(conn, {
+            xmlns: 'urn:partner.soap.sforce.com',
+            endpointUrl: `${loginUrl}/services/Soap/u/66.0`,
+          }),
+        /SOAP API does not support JWT-based access tokens/,
+      );
+    });
+
+    it('does not throw when API version is 67.0', () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: jwtToken,
+        version: '67.0',
+      });
+
+      assert.doesNotThrow(
+        () =>
+          new SOAP(conn, {
+            xmlns: 'urn:partner.soap.sforce.com',
+            endpointUrl: `${loginUrl}/services/Soap/u/67.0`,
+          }),
+      );
+    });
+
+    it('does not throw when API version is above 67.0', () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: jwtToken,
+        version: '68.0',
+      });
+
+      assert.doesNotThrow(
+        () =>
+          new SOAP(conn, {
+            xmlns: 'urn:partner.soap.sforce.com',
+            endpointUrl: `${loginUrl}/services/Soap/u/68.0`,
+          }),
+      );
+    });
+
+    it('does not throw for non-JWT tokens regardless of version', () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'access_token',
+        version: '50.0',
+      });
+
+      assert.doesNotThrow(
+        () =>
+          new SOAP(conn, {
+            xmlns: 'urn:partner.soap.sforce.com',
+            endpointUrl: `${loginUrl}/services/Soap/u/50.0`,
+          }),
+      );
+    });
+  });
+
   it('parses errors in XML responses', () => {
     const conn = new Connection({
       loginUrl,


### PR DESCRIPTION
## Summary
- JWT-based access tokens are now supported by the SOAP API starting in API version 67.0. Previously, the `SOAP` constructor threw for any JWT access token regardless of version.
- Gate the throw on `!conn._ensureVersion(67)` so JWT tokens pass through on v67.0+, and update the error message to direct users to upgrade the API version as an alternative fix.

## Test plan
- [x] Added 4 unit tests in `test/http-api.test.ts` covering: below 67.0 (throws), 67.0 (allowed), above 67.0 (allowed), non-JWT tokens at any version (allowed).
- [x] `npm run test:node -- test/http-api.test.ts` — 33/33 pass.
- [x] `npm run lint` — clean.

@W-22352136@

🤖 Generated with [Claude Code](https://claude.com/claude-code)