### PR TITLE
fix: timeouts calculate once instead of repeatedly @W-22473603@

### DIFF
--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -594,11 +594,12 @@ export class RetrieveResultLocator<S extends Schema> extends AsyncResultLocator<
 
     return new Promise<RetrieveResult>((resolve, reject) => {
       const startTime = new Date().getTime();
+      const timeoutTime = startTime + this._meta.pollTimeout;
 
       const poll = async () => {
         try {
           const now = new Date().getTime();
-          if (startTime + this._meta.pollTimeout < now) {
+          if (timeoutTime < now) {
             const err = new Error('Polling time out. Retrieve operation is not completed.');
             this.emit('error', err);
             reject(err);
@@ -672,11 +673,12 @@ export class DeployResultLocator<S extends Schema> extends AsyncResultLocator<
 
     return new Promise<DeployResult>((resolve, reject) => {
       const startTime = new Date().getTime();
+      const timeoutTime = startTime + this._meta.pollTimeout;
 
       const poll = async () => {
         try {
           const now = new Date().getTime();
-          if (startTime + this._meta.pollTimeout < now) {
+          if (timeoutTime < now) {
             const err = new Error('Polling time out. Deploy operation is not completed.');
             this.emit('error', err);
             reject(err);


### PR DESCRIPTION
This fixes an issue where the timeout for certain operations was being recalculated during every polling attempt, which was causing unexpected failures if the timeout was changed out from under the transaction. Now, the timeout is calculated once at the start of the request, and should remain consistent throughout that transaction even if another transaction attempts to change it later.

@W-22473603@