### PR TITLE
feat(soql-builder): add NULLS FIRST/LAST support to ORDER BY clause

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -7,7 +7,7 @@ import { Logger, getLogger } from './util/logger';
 import RecordStream, { Serializable } from './record-stream';
 import Connection from './connection';
 import { createSOQL } from './soql-builder';
-import { QueryConfig as SOQLQueryConfig, SortDir } from './soql-builder';
+import { QueryConfig as SOQLQueryConfig, SortDir, SortNulls } from './soql-builder';
 import {
   Record,
   Optional,
@@ -92,7 +92,7 @@ export type QuerySort<
   | {
       [K in keyof R]?: SortDir;
     }
-  | Array<[keyof R, SortDir]>;
+  | Array<[keyof R, SortDir, SortNulls?]>;
 
 /**
  *
@@ -376,10 +376,11 @@ export class Query<
    * Set query sort with direction
    */
   sort(sort: QuerySort<S, N>|string): this;
-  sort(sort: SObjectFieldNames<S, N>|string, dir: SortDir): this;
+  sort(sort: SObjectFieldNames<S, N>|string, dir: SortDir, nulls?: SortNulls): this;
   sort(
     sort: QuerySort<S, N> | SObjectFieldNames<S, N> | string,
     dir?: SortDir,
+    nulls?: SortNulls,
   ) {
     if (this._soql) {
       throw Error(
@@ -387,7 +388,7 @@ export class Query<
       );
     }
     if (typeof sort === 'string' && typeof dir !== 'undefined') {
-      this._config.sort = [[sort, dir]];
+      this._config.sort = nulls != null ? [[sort, dir, nulls]] : [[sort, dir]];
     } else {
       this._config.sort = sort as string | { [field: string]: SortDir };
     }
@@ -1286,12 +1287,13 @@ export class SubQuery<
    * Set query sort with direction
    */
   sort(sort: QuerySort<S, CN>): this;
-  sort(sort: string| SObjectFieldNames<S, CN>, dir: SortDir): this;
+  sort(sort: string| SObjectFieldNames<S, CN>, dir: SortDir, nulls?: SortNulls): this;
   sort(
     sort: QuerySort<S, CN> | SObjectFieldNames<S, CN> | string,
     dir?: SortDir,
+    nulls?: SortNulls,
   ) {
-    this._query = this._query.sort(sort as any, dir as SortDir);
+    this._query = this._query.sort(sort as any, dir as SortDir, nulls as SortNulls);
     return this;
   }
 

--- a/src/soql-builder.ts
+++ b/src/soql-builder.ts
@@ -12,9 +12,11 @@ export type Condition =
 
 export type SortDir = 'ASC' | 'DESC' | 'asc' | 'desc' | 1 | -1;
 
+export type SortNulls = 'FIRST' | 'LAST' | 'first' | 'last';
+
 export type Sort =
   | string
-  | Array<[string, SortDir]>
+  | Array<[string, SortDir, SortNulls?]>
   | { [field: string]: SortDir };
 
 export type QueryConfig = {
@@ -129,7 +131,7 @@ function createFieldExpression(field: string, value: any): Optional<string> {
 
 /** @private **/
 function createOrderByClause(sort: Sort = []): string {
-  let _sort: Array<[string, SortDir]> = [];
+  let _sort: Array<[string, SortDir, SortNulls?]> = [];
   if (typeof sort === 'string') {
     if (/,|\s+(asc|desc)\s*$/.test(sort)) {
       // must be specified in pure "order by" clause. Return raw config.
@@ -156,7 +158,7 @@ function createOrderByClause(sort: Sort = []): string {
     );
   }
   return _sort
-    .map(([field, dir]) => {
+    .map(([field, dir, nulls]) => {
       /* eslint-disable no-param-reassign */
       switch (String(dir)) {
         case 'DESC':
@@ -169,7 +171,14 @@ function createOrderByClause(sort: Sort = []): string {
         default:
           dir = 'ASC';
       }
-      return `${field} ${dir}`;
+      let clause = `${field} ${dir}`;
+      if (nulls != null) {
+        const n = String(nulls).toUpperCase();
+        if (n === 'FIRST' || n === 'LAST') {
+          clause += ` NULLS ${n}`;
+        }
+      }
+      return clause;
     })
     .join(', ');
 }

--- a/test/soql-builder.test.ts
+++ b/test/soql-builder.test.ts
@@ -316,4 +316,57 @@ describe('soql-builder', () => {
           'LIMIT 10',
     );
   });
+
+  //
+  it('should build query with NULLS LAST on a single field', () => {
+    const soql = createSOQL({
+      table: 'Opportunity',
+      sort: [['CloseDate', 'ASC', 'LAST']],
+      limit: 10,
+    });
+    assert.ok(
+      soql ===
+        'SELECT Id FROM Opportunity ' +
+          'ORDER BY CloseDate ASC NULLS LAST ' +
+          'LIMIT 10',
+    );
+  });
+
+  //
+  it('should build query with NULLS FIRST on a single field', () => {
+    const soql = createSOQL({
+      table: 'Opportunity',
+      sort: [['CloseDate', 'DESC', 'FIRST']],
+      limit: 10,
+    });
+    assert.ok(
+      soql ===
+        'SELECT Id FROM Opportunity ' +
+          'ORDER BY CloseDate DESC NULLS FIRST ' +
+          'LIMIT 10',
+    );
+  });
+
+  //
+  it('should build query with mixed NULLS placement across multiple sort fields', () => {
+    const soql = createSOQL({
+      table: 'Opportunity',
+      conditions: {
+        'Owner.Name': { $like: 'A%' },
+      },
+      sort: [
+        ['CloseDate', 'ASC', 'LAST'],
+        ['CreatedDate', 'DESC'],
+        ['Name', 'ASC', 'FIRST'],
+      ],
+      limit: 10,
+    });
+    assert.ok(
+      soql ===
+        'SELECT Id FROM Opportunity ' +
+          "WHERE Owner.Name LIKE 'A%' " +
+          'ORDER BY CloseDate ASC NULLS LAST, CreatedDate DESC, Name ASC NULLS FIRST ' +
+          'LIMIT 10',
+    );
+  });
 });


### PR DESCRIPTION
## Problem

SOQL natively supports `NULLS FIRST` and `NULLS LAST` in the `ORDER BY` clause, but jsforce had no way to express this through any of its existing APIs. For nullable fields (e.g. dates, optional lookups), Salesforce defaults to placing `null` values first on `ASC` and last on `DESC`. There was no way to control this behaviour without dropping down to raw SOQL strings.

Previously reported in issue #663.

## Solution

Added an optional third element `SortNulls?` to the existing tuple-array format of `Sort`. The change is **fully backwards-compatible** — all existing call sites work without modification.

### New type

```typescript
export type SortNulls = 'FIRST' | 'LAST' | 'first' | 'last';
```

### New API

**Tuple array (multi-field):**
```typescript
conn.sobject('Opportunity')
  .select('Id, CloseDate, Name')
  .sort([
    ['CloseDate', 'ASC', 'LAST'],  // nulls at the end
    ['Name',      'ASC'],           // unchanged — as before
  ])
  .execute();
// ORDER BY CloseDate ASC NULLS LAST, Name ASC
```

**Two-argument shorthand (single field):**
```typescript
conn.sobject('Opportunity')
  .select('Id, CloseDate')
  .sort('CloseDate', 'ASC', 'LAST')
  .execute();
// ORDER BY CloseDate ASC NULLS LAST LIMIT 10
```

### Generated SOQL

```sql
SELECT Id, CloseDate FROM Opportunity ORDER BY CloseDate ASC NULLS LAST LIMIT 10
```

## Changed files

| File | Change |
|---|---|
| `src/soql-builder.ts` | New `SortNulls` type; extended `Sort` type; `createOrderByClause` appends `NULLS FIRST/LAST` when provided |
| `src/query.ts` | Import `SortNulls`; extended `QuerySort`; optional third `nulls?` argument on both `sort()` overloads |
| `test/soql-builder.test.ts` | Three new test cases: NULLS LAST, NULLS FIRST, mixed per-field |

## Notes

- No breaking changes — the object form `{ field: 'ASC' }` and mongoose-style strings (`'-CreatedDate'`) are unaffected
- Lowercase values `'first'`/`'last'` are normalised to `FIRST`/`LAST` before being appended to SOQL
- Unknown `nulls` values are silently ignored — the generated SOQL remains valid