### PR TITLE
feat(schema): generate literal union types from picklist values (--picklistEnums)

### DIFF
--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -164,6 +164,25 @@ export function getFieldTSType(
   return getTSTypeString(field.type);
 }
 
+export function buildMultipicklistFieldJSDoc(
+  objectName: string,
+  field: FieldTypeInput,
+  picklistEnums: boolean,
+): string | null {
+  if (!picklistEnums || field.type !== 'multipicklist') {
+    return null;
+  }
+  if (getActivePicklistValues(field.picklistValues).length === 0) {
+    return null;
+  }
+  return (
+    '  /**\n' +
+    '   * Multi-select picklist — semicolon-delimited combination of\n' +
+    `   * {@link PicklistValues$${objectName}$${field.name}} values (e.g. \`"A;C"\`).\n` +
+    '   */'
+  );
+}
+
 async function dumpSchema(
   conn: Connection,
   orgId: string,

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -315,6 +315,7 @@ type GeneratorCommand = {
   cache?: boolean;
   clearCache?: boolean;
   filterObjects?: Set<string>;
+  picklistEnums?: boolean;
 } & Command;
 
 function commaSeparatedList(value: string, _dummyPrevious: unknown) {
@@ -353,6 +354,10 @@ function readCommand(): GeneratorCommand {
       'Only output schema for specified objects',
       commaSeparatedList,
     )
+    .option(
+      '--picklistEnums',
+      'Generate literal union types (PicklistValues$<Object>$<Field>) from picklist values instead of plain string',
+    )
     .version(VERSION)
     .parse(process.argv) as GeneratorCommand;
 }
@@ -376,6 +381,7 @@ export default async function main() {
     program.schemaName,
     program.cache,
     program.filterObjects,
+    program.picklistEnums,
   );
   if (program.clearCache) {
     console.log('removing cache files');

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -9,6 +9,19 @@ import { mkdir } from 'fs';
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : never;
 
+export type PicklistEntryInput = {
+  active: boolean;
+  value: string;
+  label?: string | null;
+};
+
+export type FieldTypeInput = {
+  name: string;
+  type: string;
+  restrictedPicklist?: boolean;
+  picklistValues?: PicklistEntryInput[] | null;
+};
+
 function getCacheFileDir() {
   return path.join(os.tmpdir(), 'jsforce-gen-schema-cache');
 }
@@ -96,6 +109,23 @@ function getTSTypeString(type: string): string {
 
 export function toStringLiteral(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+export function getActivePicklistValues(
+  picklistValues?: PicklistEntryInput[] | null,
+): PicklistEntryInput['value'][] {
+  if (!picklistValues) {
+    return [];
+  }
+  const seen = new Set<PicklistEntryInput['value']>();
+  const values: PicklistEntryInput['value'][] = [];
+  for (const entry of picklistValues) {
+    if (entry.active && !seen.has(entry.value)) {
+      seen.add(entry.value);
+      values.push(entry.value);
+    }
+  }
+  return values;
 }
 
 async function dumpSchema(

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -94,6 +94,10 @@ function getTSTypeString(type: string): string {
     : 'string';
 }
 
+export function toStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
 async function dumpSchema(
   conn: Connection,
   orgId: string,

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -143,6 +143,27 @@ export function buildPicklistUnion(
   return `export type PicklistValues$${objectName}$${field.name} =\n${members};`;
 }
 
+export function getFieldTSType(
+  objectName: string,
+  field: FieldTypeInput,
+  picklistEnums: boolean,
+): string {
+  if (!picklistEnums) {
+    return getTSTypeString(field.type);
+  }
+  if (field.type === 'picklist') {
+    const values = getActivePicklistValues(field.picklistValues);
+    if (values.length === 0) {
+      return 'string';
+    }
+    const unionName = `PicklistValues$${objectName}$${field.name}`;
+    return field.restrictedPicklist ? unionName : `${unionName} | (string & {})`;
+  }
+  // multipicklist stays `string` (its value union is still emitted separately,
+  // and documented via JSDoc); all other types delegate unchanged.
+  return getTSTypeString(field.type);
+}
+
 async function dumpSchema(
   conn: Connection,
   orgId: string,

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -190,6 +190,7 @@ async function dumpSchema(
   schemaName: string,
   cache?: boolean,
   filterObjects?: Set<string>,
+  picklistEnums?: boolean,
 ) {
   const sobjects =
     (cache ? await readDescribedCache(orgId) : null) ||
@@ -212,12 +213,29 @@ async function dumpSchema(
         continue;
       }
       const { name, fields, childRelationships } = sobject;
+      if (picklistEnums) {
+        for (const field of fields) {
+          const union = buildPicklistUnion(name, field);
+          if (union) {
+            writeLine(union);
+            writeLine('');
+          }
+        }
+      }
       writeLine(`type Fields$${name} = {`);
       writeLine('  //');
-      for (const { name, type, nillable } of fields) {
-        const tsType = getTSTypeString(type);
-        const orNull = nillable ? ' | null' : '';
-        writeLine(`  ${name}: ${tsType}${orNull};`);
+      for (const field of fields) {
+        const jsDoc = buildMultipicklistFieldJSDoc(
+          name,
+          field,
+          Boolean(picklistEnums),
+        );
+        if (jsDoc) {
+          writeLine(jsDoc);
+        }
+        const tsType = getFieldTSType(name, field, Boolean(picklistEnums));
+        const orNull = field.nillable ? ' | null' : '';
+        writeLine(`  ${field.name}: ${tsType}${orNull};`);
       }
       writeLine('};');
       writeLine('');

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -128,6 +128,21 @@ export function getActivePicklistValues(
   return values;
 }
 
+export function buildPicklistUnion(
+  objectName: string,
+  field: FieldTypeInput,
+): string | null {
+  if (field.type !== 'picklist' && field.type !== 'multipicklist') {
+    return null;
+  }
+  const values = getActivePicklistValues(field.picklistValues);
+  if (values.length === 0) {
+    return null;
+  }
+  const members = values.map((v) => `  | ${toStringLiteral(v)}`).join('\n');
+  return `export type PicklistValues$${objectName}$${field.name} =\n${members};`;
+}
+
 async function dumpSchema(
   conn: Connection,
   orgId: string,

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { toStringLiteral, getActivePicklistValues } from '../src/schema/generator';
+import { toStringLiteral, getActivePicklistValues, buildPicklistUnion } from '../src/schema/generator';
 
 describe('toStringLiteral', () => {
   it('wraps a plain value in single quotes', () => {
@@ -67,6 +67,82 @@ describe('getActivePicklistValues', () => {
         { active: true, value: 'A' },
       ]),
       ['A'],
+    );
+  });
+});
+
+describe('buildPicklistUnion', () => {
+  it('returns null for non-picklist fields', () => {
+    assert.strictEqual(
+      buildPicklistUnion('Opportunity', { name: 'Amount', type: 'currency' }),
+      null,
+    );
+  });
+
+  it('returns null when there are no active values', () => {
+    assert.strictEqual(
+      buildPicklistUnion('Opportunity', {
+        name: 'StageName',
+        type: 'picklist',
+        picklistValues: [{ active: false, value: 'Old' }],
+      }),
+      null,
+    );
+  });
+
+  it('builds an exported union from active values for a picklist', () => {
+    const decl = buildPicklistUnion('Opportunity', {
+      name: 'StageName',
+      type: 'picklist',
+      picklistValues: [
+        { active: true, value: 'Qualification' },
+        { active: true, value: 'Closed Won' },
+      ],
+    });
+    assert.strictEqual(
+      decl,
+      "export type PicklistValues$Opportunity$StageName =\n" +
+        "  | 'Qualification'\n" +
+        "  | 'Closed Won';",
+    );
+  });
+
+  it('builds a union for multipicklist fields too', () => {
+    const decl = buildPicklistUnion('Account', {
+      name: 'Domains__c',
+      type: 'multipicklist',
+      picklistValues: [{ active: true, value: 'A' }],
+    });
+    assert.strictEqual(
+      decl,
+      "export type PicklistValues$Account$Domains__c =\n  | 'A';",
+    );
+  });
+
+  it('escapes special characters in values', () => {
+    const decl = buildPicklistUnion('Account', {
+      name: 'Owner__c',
+      type: 'picklist',
+      picklistValues: [{ active: true, value: "O'Brien" }],
+    });
+    assert.strictEqual(
+      decl,
+      "export type PicklistValues$Account$Owner__c =\n  | 'O\\'Brien';",
+    );
+  });
+
+  it('returns null for a picklist with null/absent picklistValues', () => {
+    assert.strictEqual(
+      buildPicklistUnion('Opportunity', { name: 'StageName', type: 'picklist' }),
+      null,
+    );
+    assert.strictEqual(
+      buildPicklistUnion('Opportunity', {
+        name: 'StageName',
+        type: 'picklist',
+        picklistValues: null,
+      }),
+      null,
     );
   });
 });

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { toStringLiteral, getActivePicklistValues, buildPicklistUnion, getFieldTSType } from '../src/schema/generator';
+import { toStringLiteral, getActivePicklistValues, buildPicklistUnion, getFieldTSType, buildMultipicklistFieldJSDoc } from '../src/schema/generator';
 
 describe('toStringLiteral', () => {
   it('wraps a plain value in single quotes', () => {
@@ -242,6 +242,61 @@ describe('getFieldTSType', () => {
         true,
       ),
       'PicklistValues$Opportunity$StageName | (string & {})',
+    );
+  });
+});
+
+describe('buildMultipicklistFieldJSDoc', () => {
+  const multi = {
+    name: 'Domains__c',
+    type: 'multipicklist',
+    picklistValues: [{ active: true, value: 'A' }],
+  };
+
+  it('returns null when flag is off', () => {
+    assert.strictEqual(buildMultipicklistFieldJSDoc('Account', multi, false), null);
+  });
+
+  it('returns null for non-multipicklist fields', () => {
+    assert.strictEqual(
+      buildMultipicklistFieldJSDoc(
+        'Account',
+        { name: 'X', type: 'picklist', picklistValues: [{ active: true, value: 'A' }] },
+        true,
+      ),
+      null,
+    );
+  });
+
+  it('returns null for a multipicklist with no active values', () => {
+    assert.strictEqual(
+      buildMultipicklistFieldJSDoc(
+        'Account',
+        { name: 'Domains__c', type: 'multipicklist', picklistValues: [] },
+        true,
+      ),
+      null,
+    );
+  });
+
+  it('builds a JSDoc block linking the value union for multipicklist', () => {
+    assert.strictEqual(
+      buildMultipicklistFieldJSDoc('Account', multi, true),
+      '  /**\n' +
+        '   * Multi-select picklist — semicolon-delimited combination of\n' +
+        '   * {@link PicklistValues$Account$Domains__c} values (e.g. `"A;C"`).\n' +
+        '   */',
+    );
+  });
+
+  it('returns null for a multipicklist with null picklistValues', () => {
+    assert.strictEqual(
+      buildMultipicklistFieldJSDoc(
+        'Account',
+        { name: 'Domains__c', type: 'multipicklist', picklistValues: null },
+        true,
+      ),
+      null,
     );
   });
 });

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { toStringLiteral } from '../src/schema/generator';
+import { toStringLiteral, getActivePicklistValues } from '../src/schema/generator';
 
 describe('toStringLiteral', () => {
   it('wraps a plain value in single quotes', () => {
@@ -16,5 +16,57 @@ describe('toStringLiteral', () => {
 
   it('escapes a backslash immediately followed by a single quote', () => {
     assert.strictEqual(toStringLiteral("a\\'b"), "'a\\\\\\'b'");
+  });
+});
+
+describe('getActivePicklistValues', () => {
+  it('returns [] when picklistValues is missing', () => {
+    assert.deepStrictEqual(getActivePicklistValues(null), []);
+    assert.deepStrictEqual(getActivePicklistValues(undefined), []);
+  });
+
+  it('keeps only active entries and maps to .value', () => {
+    const result = getActivePicklistValues([
+      { active: true, value: 'A' },
+      { active: false, value: 'B' },
+      { active: true, value: 'C' },
+    ]);
+    assert.deepStrictEqual(result, ['A', 'C']);
+  });
+
+  it('uses value, not label', () => {
+    const result = getActivePicklistValues([
+      { active: true, value: 'api_val', label: 'Pretty Label' },
+    ]);
+    assert.deepStrictEqual(result, ['api_val']);
+  });
+
+  it('de-duplicates while preserving order', () => {
+    const result = getActivePicklistValues([
+      { active: true, value: 'A' },
+      { active: true, value: 'A' },
+      { active: true, value: 'B' },
+    ]);
+    assert.deepStrictEqual(result, ['A', 'B']);
+  });
+
+  it('returns [] when all entries are inactive', () => {
+    assert.deepStrictEqual(
+      getActivePicklistValues([
+        { active: false, value: 'A' },
+        { active: false, value: 'B' },
+      ]),
+      [],
+    );
+  });
+
+  it('an inactive entry does not block a later active entry with the same value', () => {
+    assert.deepStrictEqual(
+      getActivePicklistValues([
+        { active: false, value: 'A' },
+        { active: true, value: 'A' },
+      ]),
+      ['A'],
+    );
   });
 });

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import { toStringLiteral } from '../src/schema/generator';
+
+describe('toStringLiteral', () => {
+  it('wraps a plain value in single quotes', () => {
+    assert.strictEqual(toStringLiteral('Closed Won'), "'Closed Won'");
+  });
+
+  it('escapes single quotes', () => {
+    assert.strictEqual(toStringLiteral("O'Brien"), "'O\\'Brien'");
+  });
+
+  it('escapes backslashes', () => {
+    assert.strictEqual(toStringLiteral('a\\b'), "'a\\\\b'");
+  });
+
+  it('escapes a backslash immediately followed by a single quote', () => {
+    assert.strictEqual(toStringLiteral("a\\'b"), "'a\\\\\\'b'");
+  });
+});

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -101,7 +101,7 @@ describe('buildPicklistUnion', () => {
     });
     assert.strictEqual(
       decl,
-      "export type PicklistValues$Opportunity$StageName =\n" +
+      'export type PicklistValues$Opportunity$StageName =\n' +
         "  | 'Qualification'\n" +
         "  | 'Closed Won';",
     );

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { toStringLiteral, getActivePicklistValues, buildPicklistUnion } from '../src/schema/generator';
+import { toStringLiteral, getActivePicklistValues, buildPicklistUnion, getFieldTSType } from '../src/schema/generator';
 
 describe('toStringLiteral', () => {
   it('wraps a plain value in single quotes', () => {
@@ -143,6 +143,105 @@ describe('buildPicklistUnion', () => {
         picklistValues: null,
       }),
       null,
+    );
+  });
+});
+
+describe('getFieldTSType', () => {
+  const restrictedPicklist = {
+    name: 'StageName',
+    type: 'picklist',
+    restrictedPicklist: true,
+    picklistValues: [{ active: true, value: 'Qualification' }],
+  };
+  const unrestrictedPicklist = {
+    name: 'StageName',
+    type: 'picklist',
+    restrictedPicklist: false,
+    picklistValues: [{ active: true, value: 'Qualification' }],
+  };
+
+  it('falls back to getTSTypeString behavior when flag is off', () => {
+    assert.strictEqual(
+      getFieldTSType('Opportunity', restrictedPicklist, false),
+      'string',
+    );
+  });
+
+  it('uses the named union for a restricted picklist', () => {
+    assert.strictEqual(
+      getFieldTSType('Opportunity', restrictedPicklist, true),
+      'PicklistValues$Opportunity$StageName',
+    );
+  });
+
+  it('adds open string for an unrestricted picklist', () => {
+    assert.strictEqual(
+      getFieldTSType('Opportunity', unrestrictedPicklist, true),
+      'PicklistValues$Opportunity$StageName | (string & {})',
+    );
+  });
+
+  it('keeps multipicklist as string even with flag on', () => {
+    assert.strictEqual(
+      getFieldTSType(
+        'Account',
+        {
+          name: 'Domains__c',
+          type: 'multipicklist',
+          picklistValues: [{ active: true, value: 'A' }],
+        },
+        true,
+      ),
+      'string',
+    );
+  });
+
+  it('falls back to string for a picklist with no active values', () => {
+    assert.strictEqual(
+      getFieldTSType(
+        'Opportunity',
+        { name: 'StageName', type: 'picklist', picklistValues: [] },
+        true,
+      ),
+      'string',
+    );
+  });
+
+  it('delegates non-picklist types to getTSTypeString (flag on)', () => {
+    assert.strictEqual(
+      getFieldTSType('Opportunity', { name: 'Amount', type: 'currency' }, true),
+      'number',
+    );
+    assert.strictEqual(
+      getFieldTSType('Opportunity', { name: 'CloseDate', type: 'date' }, true),
+      'DateString',
+    );
+  });
+
+  it('falls back to string for a picklist with null picklistValues (flag on)', () => {
+    assert.strictEqual(
+      getFieldTSType(
+        'Opportunity',
+        { name: 'StageName', type: 'picklist', picklistValues: null },
+        true,
+      ),
+      'string',
+    );
+  });
+
+  it('treats a picklist with absent restrictedPicklist as unrestricted (open union)', () => {
+    assert.strictEqual(
+      getFieldTSType(
+        'Opportunity',
+        {
+          name: 'StageName',
+          type: 'picklist',
+          picklistValues: [{ active: true, value: 'Qualification' }],
+        },
+        true,
+      ),
+      'PicklistValues$Opportunity$StageName | (string & {})',
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds a new opt-in `--picklistEnums` flag to `jsforce-gen-schema` that emits reusable exported literal-union types from Salesforce picklist metadata, instead of the current wide `string`.
- When the flag is **off** (default), generated output is byte-for-byte identical to before — no breaking change.
- When **on**: restricted picklists → `PicklistValues$<Object>$<Field>`; unrestricted picklists → `PicklistValues$<Object>$<Field> | (string & {})` (autocomplete + accepts any string); multi-select picklists → field stays `string` but the value union is still emitted (for `satisfies`/`.join(';')` use) with a JSDoc `{@link}` on the field.

## Design decisions

- **Restricted vs unrestricted**: `restrictedPicklist: boolean` on the field descriptor drives whether the union is closed or open (`| (string & {})`). The open-union pattern preserves IDE autocomplete while remaining type-accurate for unrestricted picklists.
- **Multi-select as `string`**: combining enum values into a template-literal type (`'A' | 'B' | 'A;B' | ...`) blows up exponentially (TS2590) for real picklists. The value union is still emitted so consumers can write `['A', 'B'] satisfies PicklistValues$Obj$Field[]` and `.join(';')`.
- **Active values only**: inactive entries (`active: false`) are excluded, matching what the picklist currently accepts.
- **Values, not labels**: union members use the entry's `.value` (the API-level identifier returned in queries), not `.label`.

## Changes

- `src/schema/generator.ts` — five pure exported helpers (`toStringLiteral`, `getActivePicklistValues`, `buildPicklistUnion`, `getFieldTSType`, `buildMultipicklistFieldJSDoc`), the `--picklistEnums` CLI flag wired through `GeneratorCommand` → `readCommand()` → `main()` → `dumpSchema`.
- `test/schema-generator.test.ts` (new) — 29 unit tests for the pure helpers, runnable without a live Salesforce connection.

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npx eslint src/schema/generator.ts test/schema-generator.test.ts` — clean
- [ ] `npx jest test/schema-generator.test.ts` — 29/29 pass
- [ ] Run `jsforce-gen-schema` **without** `--picklistEnums` against a real org — output unchanged
- [ ] Run `jsforce-gen-schema --picklistEnums` against a real org — `PicklistValues$*` types appear before each `Fields$*` block for picklist/multipicklist fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)