### PR TITLE
feat(schema): emit dynamic import type with only used types

### DIFF
--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -133,9 +133,12 @@ async function dumpSchema(
     out.on('error', (err) => reject(err));
     out.on('finish', resolve);
     const writeLine = (message: string) => out.write(message + '\n');
-    writeLine(
-      "import { Schema, SObjectDefinition, DateString, BlobString, Address } from 'jsforce';",
+    const usedConditionalTypes = collectUsedJsforceTypes(sobjects, filterObjects);
+    const orderedConditionalTypes = ['DateString', 'BlobString', 'Address'].filter(
+      (t) => usedConditionalTypes.has(t),
     );
+    const importNames = ['Schema', 'SObjectDefinition', ...orderedConditionalTypes].join(', ');
+    writeLine(`import type { ${importNames} } from 'jsforce';`);
     writeLine('');
     for (const sobject of sobjects) {
       if (filterObjects && !filterObjects.has(sobject.name)) {

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -133,11 +133,17 @@ async function dumpSchema(
     out.on('error', (err) => reject(err));
     out.on('finish', resolve);
     const writeLine = (message: string) => out.write(message + '\n');
+    const includedSobjects = filterObjects
+      ? sobjects.filter((s) => filterObjects.has(s.name))
+      : sobjects;
     const usedConditionalTypes = collectUsedJsforceTypes(sobjects, filterObjects);
     const orderedConditionalTypes = ['DateString', 'BlobString', 'Address'].filter(
       (t) => usedConditionalTypes.has(t),
     );
-    const importNames = ['Schema', 'SObjectDefinition', ...orderedConditionalTypes].join(', ');
+    const baseImports = includedSobjects.length > 0
+      ? ['Schema', 'SObjectDefinition']
+      : ['Schema'];
+    const importNames = [...baseImports, ...orderedConditionalTypes].join(', ');
     writeLine(`import type { ${importNames} } from 'jsforce';`);
     writeLine('');
     for (const sobject of sobjects) {

--- a/src/schema/generator.ts
+++ b/src/schema/generator.ts
@@ -94,6 +94,25 @@ function getTSTypeString(type: string): string {
     : 'string';
 }
 
+const CONDITIONAL_JSFORCE_TYPES = new Set(['DateString', 'BlobString', 'Address']);
+
+export function collectUsedJsforceTypes(
+  sobjects: DescribeSObjectResult[],
+  filterObjects?: Set<string>,
+): Set<string> {
+  const used = new Set<string>();
+  for (const sobject of sobjects) {
+    if (filterObjects && !filterObjects.has(sobject.name)) continue;
+    for (const { type } of sobject.fields) {
+      const tsType = getTSTypeString(type);
+      if (CONDITIONAL_JSFORCE_TYPES.has(tsType)) {
+        used.add(tsType);
+      }
+    }
+  }
+  return used;
+}
+
 async function dumpSchema(
   conn: Connection,
   orgId: string,

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,0 +1,71 @@
+import { collectUsedJsforceTypes } from '../src/schema/generator';
+import type { DescribeSObjectResult } from '../src/types/common';
+
+function makeSobject(
+  name: string,
+  fieldTypes: string[],
+): DescribeSObjectResult {
+  return {
+    name,
+    fields: fieldTypes.map((type, i) => ({ name: `Field${i}`, type, nillable: false }) as any),
+    childRelationships: [],
+  } as unknown as DescribeSObjectResult;
+}
+
+describe('collectUsedJsforceTypes', () => {
+  it('returns empty set when no conditional types are used', () => {
+    const sobjects = [makeSobject('Obj', ['string', 'boolean', 'int', 'double'])];
+    expect(collectUsedJsforceTypes(sobjects)).toEqual(new Set());
+  });
+
+  it('detects DateString for date, datetime, and time fields', () => {
+    const sobjects = [makeSobject('Obj', ['date'])];
+    expect(collectUsedJsforceTypes(sobjects)).toEqual(new Set(['DateString']));
+
+    const sobjects2 = [makeSobject('Obj', ['datetime'])];
+    expect(collectUsedJsforceTypes(sobjects2)).toEqual(new Set(['DateString']));
+
+    const sobjects3 = [makeSobject('Obj', ['time'])];
+    expect(collectUsedJsforceTypes(sobjects3)).toEqual(new Set(['DateString']));
+  });
+
+  it('detects BlobString for base64 fields', () => {
+    const sobjects = [makeSobject('Obj', ['base64'])];
+    expect(collectUsedJsforceTypes(sobjects)).toEqual(new Set(['BlobString']));
+  });
+
+  it('detects Address for address fields', () => {
+    const sobjects = [makeSobject('Obj', ['address'])];
+    expect(collectUsedJsforceTypes(sobjects)).toEqual(new Set(['Address']));
+  });
+
+  it('detects multiple types across multiple sobjects', () => {
+    const sobjects = [
+      makeSobject('A', ['date', 'string']),
+      makeSobject('B', ['base64', 'address']),
+    ];
+    expect(collectUsedJsforceTypes(sobjects)).toEqual(
+      new Set(['DateString', 'BlobString', 'Address']),
+    );
+  });
+
+  it('respects filterObjects — excludes types from filtered-out sobjects', () => {
+    const sobjects = [
+      makeSobject('Included', ['string']),
+      makeSobject('Excluded', ['base64', 'address']),
+    ];
+    const filter = new Set(['Included']);
+    expect(collectUsedJsforceTypes(sobjects, filter)).toEqual(new Set());
+  });
+
+  it('respects filterObjects — includes types from allowed sobjects', () => {
+    const sobjects = [
+      makeSobject('Included', ['date']),
+      makeSobject('Excluded', ['base64']),
+    ];
+    const filter = new Set(['Included']);
+    expect(collectUsedJsforceTypes(sobjects, filter)).toEqual(
+      new Set(['DateString']),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the hardcoded `import { Schema, SObjectDefinition, DateString, BlobString, Address }` in generated schema files with a dynamic `import type { ... }` that only includes the types actually referenced in the output
- `Schema` is always included (used by `export interface ${schemaName} extends Schema`)
- `SObjectDefinition` is included only when at least one SObject is emitted
- `DateString`, `BlobString`, and `Address` are included only when at least one field maps to each respective type
- Switches to `import type` syntax since these are type-only references

## Test Plan

- [ ] Run `npx jest test/schema-generator.test.ts --no-coverage` — 7 new unit tests for `collectUsedJsforceTypes` covering: empty set, per-type detection (DateString/BlobString/Address), multi-sobject aggregation, and `filterObjects` include/exclude
- [ ] Run `npx tsc --noEmit` — no TypeScript errors
- [ ] Generate a schema against an org with no `base64` or `address` fields and confirm neither `BlobString` nor `Address` appear in the output import line