### PR TITLE
fix(browser): always use fetch in browser/web workers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,10 @@ jobs:
         run: npm install
 
       - name: Install Puppeteer Chrome
-        run: npx puppeteer browsers install chrome
+        shell: bash
+        run: |
+          rm -rf "$HOME/.cache/puppeteer/chrome"
+          npx puppeteer browsers install chrome
 
       - name: Run Perf tests
         run: npm run test:node:perf
@@ -189,7 +192,10 @@ jobs:
         run: npm install
 
       - name: Install Puppeteer Chrome
-        run: npx puppeteer browsers install chrome
+        shell: bash
+        run: |
+          rm -rf "$HOME/.cache/puppeteer/chrome"
+          npx puppeteer browsers install chrome
 
       - name: Run Perf tests
         run: npm run test:node:perf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,16 +51,16 @@ jobs:
           retry_wait_seconds: 60
           command: |
             SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+            SF_PASSWORD=$(sf org auth show-user-password --target-org jsforce-test-org --json | jq -r '.result.password') \
             SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-            SF_ACCESS_TOKEN=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
+            SF_ACCESS_TOKEN=$(sf org auth show-access-token --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
             DISPLAY=:99 CHROME_BIN=$(which chrome) \
             npm run test:browser-ci
           new_command_on_retry: |
             SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-            SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+            SF_PASSWORD=$(sf org auth show-user-password --target-org jsforce-test-org --json | jq -r '.result.password') \
             SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-            SF_ACCESS_TOKEN=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
+            SF_ACCESS_TOKEN=$(sf org auth show-access-token --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
             DISPLAY=:99 CHROME_BIN=$(which chrome) \
             npm run test:browser-ci:retry
           retry_on: error
@@ -84,7 +84,6 @@ jobs:
         run: |
           npm install -g lockfile-lint
           lockfile-lint --path package-lock.json --allowed-hosts npm yarn --validate-https
-
 
       - name: Install dependencies
         run: npm install
@@ -112,7 +111,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-      
+
       - name: Run Perf tests
         run: npm run test:node:perf
 
@@ -135,9 +134,9 @@ jobs:
           SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
         run: |
           SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username') \
-          SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password') \
+          SF_PASSWORD=$(sf org auth show-user-password --target-org jsforce-test-org --json | jq -r '.result.password') \
           SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl') \
-          SF_ACCESS_TOKEN=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
+          SF_ACCESS_TOKEN=$(sf org auth show-access-token --target-org jsforce-test-org --json | jq -r '.result.accessToken') \
           npm run test:node
 
       - name: Delete scratch org
@@ -150,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ["ubuntu-latest", "windows-latest"]
         externalProjectGitUrl:
           - https://github.com/salesforcecli/plugin-org
           - https://github.com/salesforcecli/plugin-auth
@@ -159,7 +158,7 @@ jobs:
           - https://github.com/salesforcecli/plugin-custom-metadata
     with:
       externalProjectGitUrl: ${{ matrix.externalProjectGitUrl }}
-      command: 'yarn test:nuts'
+      command: "yarn test:nuts"
       os: ${{ matrix.os }}
       useCache: false
     secrets:
@@ -208,9 +207,9 @@ jobs:
           SF_OAUTH2_REDIRECT_URI: ${{ secrets.SF_OAUTH2_REDIRECT_URI }}
         run: |
           $env:SF_USERNAME=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.username')
-          $env:SF_PASSWORD=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.password')
+          $env:SF_PASSWORD=$(sf org auth show-user-password --target-org jsforce-test-org --json | jq -r '.result.password')
           $env:SF_LOGIN_URL=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.instanceUrl')
-          $env:SF_ACCESS_TOKEN=$(sf org display user --target-org jsforce-test-org --json | jq -r '.result.accessToken')
+          $env:SF_ACCESS_TOKEN=$(sf org auth show-access-token --target-org jsforce-test-org --json | jq -r '.result.accessToken')
           npm run test:node
 
       - name: Delete scratch org

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Puppeteer Chrome
+        run: npx puppeteer browsers install chrome
+
       - name: Run Perf tests
         run: npm run test:node:perf
 
@@ -184,6 +187,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Install Puppeteer Chrome
+        run: npx puppeteer browsers install chrome
 
       - name: Run Perf tests
         run: npm run test:node:perf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.10.14",
+  "version": "3.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.10.14",
+      "version": "3.10.15",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/scripts/org-setup.mjs
+++ b/scripts/org-setup.mjs
@@ -76,7 +76,11 @@ await $`sf force data bulk upsert --file ${bigTableCsv} --sobject BigTable__c --
 
 if (!process.env.CI) {
   console.log(
-    `Run tests using this scratch org by setting these env vars: SF_ACCESS_TOKEN=${orgDisplayUserRes.result.accessToken}, SF_LOGIN_URL=${orgDisplayUserRes.result.instanceUrl}, SF_USERNAME=${orgDisplayUserRes.result.username} and SF_PASSWORD=${orgDisplayUserRes.result.password}`,
+    `Run tests using this scratch org by setting these env vars:
+- SF_ACCESS_TOKEN=(Obtain with: sf org auth show-access-token),
+- SF_LOGIN_URL=${orgDisplayUserRes.result.instanceUrl},
+- SF_USERNAME=${orgDisplayUserRes.result.username},
+- SF_PASSWORD=(Obtain with: sf org auth show-user-password)`,
   );
 }
 

--- a/src/browser/request.ts
+++ b/src/browser/request.ts
@@ -147,103 +147,6 @@ async function startFetchRequest(
 /**
  *
  */
-function getResponseHeaderNames(xhr: XMLHttpRequest) {
-  const headerLines = (xhr.getAllResponseHeaders() || '')
-    .split(/[\r\n]+/)
-    .filter((l) => l.trim() !== '');
-  return headerLines.map((headerLine) =>
-    headerLine.split(/\s*:/)[0].toLowerCase(),
-  );
-}
-
-/**
- *
- */
-async function startXmlHttpRequest(
-  request: HttpRequest,
-  options: HttpRequestOptions,
-  input: Readable | undefined,
-  output: Writable,
-  emitter: EventEmitter,
-  counter: number = 0,
-) {
-  const { method, url, headers: reqHeaders } = request;
-  const { followRedirect } = options;
-  const reqBody =
-    input && /^(post|put|patch)$/i.test(method) ? await readAll(input) : null;
-  const xhr = new XMLHttpRequest();
-  await executeWithTimeout(
-    () => {
-      xhr.open(method, url);
-      if (reqHeaders) {
-        for (const header in reqHeaders) {
-          xhr.setRequestHeader(header, reqHeaders[header]);
-        }
-      }
-      if (options.timeout) {
-        xhr.timeout = options.timeout;
-      }
-      xhr.responseType = 'arraybuffer';
-      xhr.send(reqBody);
-      return new Promise<void>((resolve, reject) => {
-        xhr.onload = () => resolve();
-        xhr.onerror = reject;
-        xhr.ontimeout = reject;
-        xhr.onabort = reject;
-      });
-    },
-    options.timeout,
-    () => xhr.abort(),
-  );
-  const headerNames = getResponseHeaderNames(xhr);
-  const headers = headerNames.reduce<{ [name: string]: string }>(
-    (headers, headerName) => ({
-      ...headers,
-      [headerName]: xhr.getResponseHeader(headerName) || '',
-    }),
-    {},
-  );
-  const response = {
-    statusCode: xhr.status,
-    headers: headers,
-  };
-  if (followRedirect && isRedirect(response.statusCode)) {
-    try {
-      performRedirectRequest(
-        request,
-        response,
-        followRedirect,
-        counter,
-        (req) =>
-          startXmlHttpRequest(
-            req,
-            options,
-            undefined,
-            output,
-            emitter,
-            counter + 1,
-          ),
-      );
-    } catch (err) {
-      emitter.emit('error', err);
-    }
-    return;
-  }
-  let body: Buffer;
-  if (!response.statusCode) {
-    response.statusCode = 400;
-    body = Buffer.from('Access Declined');
-  } else {
-    body = Buffer.from(xhr.response);
-  }
-  emitter.emit('response', response);
-  output.write(body);
-  output.end();
-}
-
-/**
- *
- */
 let defaults: HttpRequestOptions = {};
 
 /**
@@ -265,10 +168,6 @@ export default function request(
     req,
     options,
   );
-  if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
-    startFetchRequest(req, options, input, output, stream);
-  } else {
-    startXmlHttpRequest(req, options, input, output, stream);
-  }
+  startFetchRequest(req, options, input, output, stream);
   return stream;
 }


### PR DESCRIPTION
## Why

`src/browser/request.ts` currently picks the transport with:

```ts
if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
  startFetchRequest(...);
} else {
  startXmlHttpRequest(...);
}
```

That gate looks at `window`, but for VS Code Extensions using JSForce`window` is `undefined` inside a Web Worker realm — so jsforce silently falls through to `XMLHttpRequest` whenever it runs in a worker. That's surprising in two ways:

- Worker realms have a working global `fetch`. Every browser jsforce supports today exposes `fetch` on both the window and worker globals, so the XHR path is dead weight in the worker case.
- Some embeddings (e.g. VS Code's web extension host worker) shim `fetch` but not `XMLHttpRequest`, which means the XHR fallback throws on construction. The result is that perfectly-modern environments fail with a transport error that looks like a jsforce bug rather than a missing primitive.

## What

- Drop the `typeof window` gate and always call `startFetchRequest`.
- Remove the now-unused `startXmlHttpRequest` and `getResponseHeaderNames` helpers (file-local; no other references in `src/`).

The fetch path was already the preferred branch in browsers; this change just extends it to worker realms and drops the dead XHR fallback. No public API change.

## Validation

Validated by running VS Code extensions that depend on jsforce against a `patch-package` build of jsforce with this exact change applied, inside a VS Code web extension host worker. Salesforce REST API calls behave identically to the previous XHR path — same URLs, same auth headers, same response shapes — and the worker realm no longer falls through to a missing `XMLHttpRequest` constructor.

<img width="2530" height="1406" alt="jsforce fetch" src="https://github.com/user-attachments/assets/979cb333-01ce-4a93-a8ee-ce939edf3558" />


Local checks on this PR's branch:

- `npm run build` — green
- `npm run lint` — green
- `npm run typecheck` — green
- `npm run test:node` — non-integration suites pass (8/24 suites, 70 tests). The remaining 16 suites fail with `URL_NOT_RESET: Destination URL not reset` because they require a live Salesforce org, which I don't have set up locally. Happy to re-run against a sandbox if you'd like — just let me know how you'd like that wired.

## Compatibility

`fetch` has been baseline in every evergreen browser since 2017 and is exposed on both `Window` and `WorkerGlobalScope`, so this should be a no-op for window-realm consumers and a strict improvement for worker-realm consumers.