### PR TITLE
fix: bump node-fetch to 2.7.0 (address AbortError)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.10.14",
+  "version": "3.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.10.14",
+      "version": "3.10.15",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
@@ -22,7 +22,7 @@
         "https-proxy-agent": "^5.0.0",
         "inquirer": "^8.2.7",
         "multistream": "^3.1.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.7.0",
         "open": "^7.0.0",
         "xml2js": "^0.6.2"
       },
@@ -41,7 +41,7 @@
         "@types/jest": "^29.5.5",
         "@types/multistream": "^2.1.1",
         "@types/node": "^18.15.3",
-        "@types/node-fetch": "^2.5.7",
+        "@types/node-fetch": "^2.6.13",
         "@types/shelljs": "^0.8.15",
         "@types/through2": "^2.0.34",
         "@types/xml2js": "^0.4.5",
@@ -3468,13 +3468,14 @@
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^4.0.0"
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/ps-tree": {

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "https-proxy-agent": "^5.0.0",
     "inquirer": "^8.2.7",
     "multistream": "^3.1.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.7.0",
     "open": "^7.0.0",
     "xml2js": "^0.6.2"
   },
@@ -251,7 +251,7 @@
     "@types/jest": "^29.5.5",
     "@types/multistream": "^2.1.1",
     "@types/node": "^18.15.3",
-    "@types/node-fetch": "^2.5.7",
+    "@types/node-fetch": "^2.6.13",
     "@types/shelljs": "^0.8.15",
     "@types/through2": "^2.0.34",
     "@types/xml2js": "^0.4.5",


### PR DESCRIPTION
This is a minor version bump for node-fetch that resolves https://github.com/jsforce/jsforce/issues/1794, where the instanceof operator is used for an un-exported AbortError.

A corresponding issue can be seen in the node-fetch repository:

- https://github.com/node-fetch/node-fetch/issues/792

Which was resolved in:

- https://github.com/node-fetch/node-fetch/pull/1744

The changelog for v2.7.0 can be found here:

- https://github.com/node-fetch/node-fetch/releases/v2.7.0
