### PR TITLE
fix: docs creation action should work again @W-23176525@

### DIFF
--- a/.github/workflows/publishDocs.yml
+++ b/.github/workflows/publishDocs.yml
@@ -2,15 +2,16 @@ name: publish-docs
 
 on: workflow_call
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SVC_CLI_BOT_JSFORCE_GITHUB_TOKEN }}
+          token: ${{ github.token }}
           ref: ${{ github.ref }}
       - uses: actions/setup-node@v3
         with:
@@ -34,5 +35,7 @@ jobs:
         run: |
           cd docs
           git add .
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m 'docs: publishing gh-pages [skip ci]' --no-verify
           git push origin gh-pages --no-verify


### PR DESCRIPTION
The Github Actions for updating documentation have been failing for a while, and this should fix them.
See #1809 and its [creation of a documentation branch](https://github.com/jsforce/jsforce/actions/runs/28603917083/job/84819039140) using the same technique used here as proof that this will work.