### PR TITLE
PIM-2093 | Republish as @propelsoftware/jsforce-propel

### DIFF
--- a/lib/VERSION.js
+++ b/lib/VERSION.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = '1.9.1';
+module.exports = '1.9.4';

--- a/lib/api/streaming-extension.js
+++ b/lib/api/streaming-extension.js
@@ -118,7 +118,7 @@ StreamingExtension.Replay = function(channel, replayId) {
   }
   
   this.outgoing = function(message, callback) {
-    if (message.channel === '/meta/subscribe') {
+    if (message.channel === '/meta/subscribe' && message.subscription === _channel) {
       if (_extensionEnabled) {
         if (!message.ext) { message.ext = {}; }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -999,7 +999,7 @@ Connection.prototype.upsert = function(type, records, extIdField, options, callb
         // be aware that `allOrNone` option in upsert method will not revert the other successful requests
         // it only raises error when met at least one failed request.
         if (!isArray || options.allOrNone || !err.errorCode) { throw err; }
-        return this._toRecordResult(null, err);
+        return self._toRecordResult(null, err);
       })
     })
   ).then(function(results) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -774,7 +774,7 @@ Connection.prototype._createParallel = function(type, records, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(null, err);
+        return self._toRecordResult(null, err);
       });
     })
   );
@@ -893,7 +893,7 @@ Connection.prototype._updateParallel = function(type, records, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(record.Id, err);
+        return self._toRecordResult(record.Id, err);
       });
     })
   );
@@ -1089,7 +1089,7 @@ Connection.prototype._destroyParallel = function(type, ids, options) {
         if (options.allOrNone || !err.errorCode) {
           throw err;
         }
-        return this._toRecordResult(id, err);
+        return self._toRecordResult(id, err);
       });
     })
   );

--- a/lib/record-stream.js
+++ b/lib/record-stream.js
@@ -113,12 +113,13 @@ inherits(Parsable, RecordStream);
 Parsable.prototype.stream = function(type, options) {
   type = type || 'csv';
   var converter = DataStreamConverters[type];
+  var self = this;
   if (!converter) {
     throw new Error('Converting [' + type + '] data stream is not supported.');
   }
   if (!this._dataStream) {
     this._dataStream = new PassThrough();
-    this._parserStream = converter.parse(options).on('error', function(error) { this.emit('error', error); });
+    this._parserStream = converter.parse(options).on('error', function(error) { self.emit('error', error); });
     this._parserStream.pipe(this).pipe(new PassThrough({ objectMode: true, highWaterMark: ( 500 * 1000 ) }));
   }
   return this._dataStream;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Shinichi Tomita <shinichi.tomita@gmail.com>",
-  "name": "jsforce",
+  "name": "@propelsoftware/jsforce-propel",
   "description": "Salesforce API Library for JavaScript",
   "keywords": [
     "salesforce",
@@ -9,11 +9,11 @@
     "force.com",
     "database.com"
   ],
-  "homepage": "http://github.com/jsforce/jsforce",
-  "version": "1.9.1",
+  "homepage": "https://github.com/PropelPLM/jsforce",
+  "version": "1.9.4",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jsforce/jsforce.git"
+    "url": "git+https://github.com/PropelPLM/jsforce.git"
   },
   "license": "MIT",
   "licenses": [


### PR DESCRIPTION
## Summary
- Renames the package from `jsforce` to `@propelsoftware/jsforce-propel` and bumps version to 1.9.4 (previously published npm package was at 1.9.3, but that bump was never committed to this repo).
- `jsforce-propel` on npm is currently maintained solely by a departed employee's personal npm account — no other collaborators, same root cause as PIM-2093 for `propel-sfdc-connect`.
- Verified `lib/connection.js` is byte-identical between this repo and the published 1.9.3 tarball, so this rename does not lose any code changes that only existed in the published package.

## Before merging / publishing
- [ ] Merge this PR
- [ ] `npm publish --access public` (matches this repo's existing public visibility) from an `@propelsoftware` org owner account
- [ ] Update consumers (`pim-data-service`, `CloudFileStorage`, possibly others) to depend on `@propelsoftware/jsforce-propel@1.9.4`

## Test plan
- [ ] `npm install` resolves cleanly under the new name
- [ ] Existing test suite still passes (no behavior change, rename + version bump only)

Ref: PIM-2093