### PR TITLE
@W-23663641 allow JWT access tokens on API v68.0+

### DIFF
--- a/src/soap.ts
+++ b/src/soap.ts
@@ -210,11 +210,16 @@ export class SOAP<S extends Schema> extends HttpApi<S> {
 
   constructor(conn: Connection<S>, options: SOAPOptions) {
     super(conn, options);
-    if (this._conn.accessToken && isJWTToken(this._conn.accessToken)) {
-      // We need to block SOAP requests with JWT tokens because the response is:
+    if (
+      this._conn.accessToken &&
+      isJWTToken(this._conn.accessToken) &&
+      !this._conn._ensureVersion(68)
+    ) {
+      // SOAP API added support for JWT-based access tokens in API v68.0 (core 264).
+      // For API v67.0 and below, JWT tokens must still be blocked because the response is:
       // statusCode=500 | body="INVALID_SESSION_ID" (xml), which triggers session refresh and enters in an infinite loop
       throw new Error(
-        'SOAP API does not support JWT-based access tokens. You must disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App',
+        'SOAP API does not support JWT-based access tokens for API versions below 68.0. Either use API version 68.0 or later, or disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App',
       );
     }
     this._endpointUrl = options.endpointUrl;

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -801,8 +801,9 @@ describe('SOAP API', () => {
 
   describe('JWT access token guard', () => {
     // A token that isJWTToken() recognizes: 3 dot-separated parts where the
-    // first part is base64-encoded JSON (here: {"alg":"RS256"}).
-    const jwtToken = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature';
+	// first part is base64-encoded JSON (here: {"alg":"RS256"}). The payload
+    // and signature are obvious placeholders, not a real credential.
+    const jwtToken = 'eyJhbGciOiJSUzI1NiJ9.NOT_A_REAL_PAYLOAD.NOT_A_REAL_SIGNATURE';
 
     function createSoap(version: string) {
       const conn = new Connection({

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -800,6 +800,55 @@ describe('SOAP API', () => {
     });
   });
 
+  describe('JWT access token guard', () => {
+    // A token that isJWTToken() recognizes: 3 dot-separated parts where the
+    // first part is base64-encoded JSON (here: {"alg":"RS256"}).
+    const jwtToken = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature';
+
+    function createSoap(version: string) {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: jwtToken,
+        version,
+      });
+      return () =>
+        new SOAP(conn, {
+          xmlns: 'urn:partner.soap.sforce.com',
+          endpointUrl: `${loginUrl}/services/Soap/u/${version}`,
+        });
+    }
+
+    it('throws for a JWT access token on API versions below 68.0', () => {
+      assert.throws(createSoap('67.0'), {
+        message:
+          'SOAP API does not support JWT-based access tokens for API versions below 68.0. Either use API version 68.0 or later, or disable the "Issue JSON Web Token (JWT)-based access tokens" setting in your Connected App or External Client App',
+      });
+    });
+
+    it('allows a JWT access token on API version 68.0 (core 264+)', () => {
+      assert.doesNotThrow(createSoap('68.0'));
+    });
+
+    it('allows a JWT access token on API versions above 68.0', () => {
+      assert.doesNotThrow(createSoap('69.0'));
+    });
+
+    it('allows a non-JWT access token on API versions below 68.0', () => {
+      const conn = new Connection({
+        loginUrl,
+        accessToken: 'not-a-jwt',
+        version: '67.0',
+      });
+      assert.doesNotThrow(
+        () =>
+          new SOAP(conn, {
+            xmlns: 'urn:partner.soap.sforce.com',
+            endpointUrl: `${loginUrl}/services/Soap/u/67.0`,
+          }),
+      );
+    });
+  });
+
   it('parses errors in XML responses', () => {
     const conn = new Connection({
       loginUrl,


### PR DESCRIPTION
SOAP API added support for JWT-based access tokens in core 264 (API v68.0). Gate the constructor throw on !conn._ensureVersion(68) so JWT tokens pass through on v68.0+ while still being blocked (with an updated message) on v67.0 and below.

Supersedes #1791

[@W-23663641@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23663641)