### PR TITLE
fix: Use URL API for OAuth2 endpoint construction @W-23807280@

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -10,6 +10,13 @@ const defaultOAuth2Config = {
   loginUrl: 'https://login.salesforce.com',
 };
 
+const appendPath = (base: string, segment: string): string => {
+  const url = new URL(base);
+  const basePath = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
+  url.pathname = `${basePath}/${segment}`;
+  return url.href;
+};
+
 // Makes a nodejs base64 encoded string compatible with rfc4648 alternative encoding for urls.
 // @param base64Encoded a nodejs base64 encoded string
 function base64UrlEscape(base64Encoded: string): string {
@@ -102,19 +109,16 @@ export class OAuth2 {
       useVerifier,
     } = config;
     if (authzServiceUrl && tokenServiceUrl) {
-      this.loginUrl = authzServiceUrl.split('/').slice(0, 3).join('/');
+      this.loginUrl = new URL(authzServiceUrl).origin;
       this.authzServiceUrl = authzServiceUrl;
       this.tokenServiceUrl = tokenServiceUrl;
       this.revokeServiceUrl =
-        revokeServiceUrl || `${this.loginUrl}/services/oauth2/revoke`;
+        revokeServiceUrl || appendPath(this.loginUrl, 'services/oauth2/revoke');
     } else {
-      this.loginUrl = loginUrl ?? defaultOAuth2Config.loginUrl
-
-      const maybeSlash = this.loginUrl.endsWith('/') ? '' : '/'
-
-      this.authzServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/authorize`
-      this.tokenServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/token`
-      this.revokeServiceUrl = `${this.loginUrl}${maybeSlash}services/oauth2/revoke`
+      this.loginUrl = loginUrl ?? defaultOAuth2Config.loginUrl;
+      this.authzServiceUrl = appendPath(this.loginUrl, 'services/oauth2/authorize');
+      this.tokenServiceUrl = appendPath(this.loginUrl, 'services/oauth2/token');
+      this.revokeServiceUrl = appendPath(this.loginUrl, 'services/oauth2/revoke');
     }
     this.clientId = clientId;
     this.clientSecret = clientSecret;

--- a/test/oauth2.test.ts
+++ b/test/oauth2.test.ts
@@ -145,4 +145,99 @@ describe('endpoints', () => {
       `${instanceUrl}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
     );
   });
+
+  it('percent-encodes injection characters in loginUrl path', () => {
+    const loginUrl = 'https://login.salesforce.com/";calc;"';
+    const encodedBase = 'https://login.salesforce.com/%22;calc;%22';
+
+    const oauth2 = new OAuth2({
+      loginUrl,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(oauth2.loginUrl, loginUrl);
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${encodedBase}/services/oauth2/authorize`,
+    );
+    assert.equal(
+      oauth2.tokenServiceUrl,
+      `${encodedBase}/services/oauth2/token`,
+    );
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${encodedBase}/services/oauth2/revoke`,
+    );
+    assert.equal(
+      oauth2.getAuthorizationUrl(),
+      `${encodedBase}/services/oauth2/authorize?response_type=code&client_id=${oauth2.clientId}&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauthredirect`,
+    );
+  });
+
+  it('does not double-encode already-encoded loginUrl paths', () => {
+    const instanceUrl = 'https://login.salesforce.com/a%20b';
+
+    const oauth2 = new OAuth2({
+      loginUrl: instanceUrl,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${instanceUrl}/services/oauth2/authorize`,
+    );
+    assert.equal(oauth2.tokenServiceUrl, `${instanceUrl}/services/oauth2/token`);
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${instanceUrl}/services/oauth2/revoke`,
+    );
+  });
+
+  it('derives loginUrl origin and revoke URL from authz/token service URLs', () => {
+    const origin = 'https://login.salesforce.com';
+    const oauth2 = new OAuth2({
+      authzServiceUrl: `${origin}/services/oauth2/authorize`,
+      tokenServiceUrl: `${origin}/services/oauth2/token`,
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(oauth2.loginUrl, origin);
+    assert.equal(
+      oauth2.authzServiceUrl,
+      `${origin}/services/oauth2/authorize`,
+    );
+    assert.equal(oauth2.tokenServiceUrl, `${origin}/services/oauth2/token`);
+    assert.equal(
+      oauth2.revokeServiceUrl,
+      `${origin}/services/oauth2/revoke`,
+    );
+  });
+
+  it('uses default loginUrl when omitted', () => {
+    const oauth2 = new OAuth2({
+      clientId: '1234test',
+      redirectUri: 'http://localhost:8080/oauthredirect',
+    });
+
+    assert.equal(oauth2.loginUrl, 'https://login.salesforce.com');
+    assert.equal(
+      oauth2.authzServiceUrl,
+      'https://login.salesforce.com/services/oauth2/authorize',
+    );
+  });
+
+  it('throws Invalid URL for scheme-less loginUrl', () => {
+    assert.throws(
+      () =>
+        new OAuth2({
+          loginUrl: 'test.salesforce.com',
+          clientId: '1234test',
+          redirectUri: 'http://localhost:8080/oauthredirect',
+        }),
+      { name: 'TypeError', message: /Invalid URL/ },
+    );
+  });
 });


### PR DESCRIPTION
re-do of #1819 with a correctly formatted commit message.

## What does this PR do?
Refactors OAuth2 endpoint URL construction to use the standard URL API instead of manual string manipulation (split/join and slash concatenation). This makes endpoint derivation more robust:
- Derives loginUrl from authzServiceUrl via new URL(authzServiceUrl).origin rather than splitting on /.
- Introduces an appendPath helper that safely joins the base URL and service path using the URL API, correctly handling trailing slashes.
- Preserves existing behavior — service paths are percent-encoded consistently, already-encoded paths are not double-encoded, and the default loginUrl is used when none is provided.

Note: a scheme-less loginUrl (e.g. test.salesforce.com) now throws a TypeError: Invalid URL, matching standard URL parsing behavior.

## What issues does this PR fix or reference?
[@W-23807280@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002hCJ0nYAG/view)