### PR TITLE
W-23797589-fix: set allowH2:false to prevent GOAWAY crashes

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
-import {fetch, errors, Response, RequestInit, ProxyAgent} from 'undici';
+import {fetch, errors, Response, RequestInit, ProxyAgent, Agent} from 'undici';
 import {
   createHttpRequestHandlerStreams,
   executeWithTimeout,
@@ -10,6 +10,9 @@ import {
 import { HttpRequest, HttpRequestOptions } from './types';
 import { getLogger } from './util/logger';
 import is from '@sindresorhus/is';
+
+// undici 8.x defaults to H2, causing crashes on server GOAWAY frames
+const noH2Agent = new Agent({ connect: { allowH2: false } });
 
 type CodedError = {
   code?: string;
@@ -40,7 +43,7 @@ async function startFetchRequest(
 ) {
   const logger = getLogger('fetch');
   const { httpProxy, followRedirect } = options;
-  const agent = httpProxy ? new ProxyAgent(httpProxy) : undefined;
+  const agent = httpProxy ? new ProxyAgent({ uri: httpProxy, requestTls: { allowH2: false } }) : noH2Agent;
   const { url, body, ...rrequest } = request;
   const controller = new AbortController();
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
-import {fetch, errors, Response, RequestInit, ProxyAgent, Agent, setGlobalDispatcher} from 'undici';
+import {fetch, errors, Response, RequestInit, ProxyAgent, Agent} from 'undici';
 import {
   createHttpRequestHandlerStreams,
   executeWithTimeout,
@@ -11,8 +11,7 @@ import { HttpRequest, HttpRequestOptions } from './types';
 import { getLogger } from './util/logger';
 import is from '@sindresorhus/is';
 
-// undici 8.x defaults to H2, causing crashes on server GOAWAY frames
-setGlobalDispatcher(new Agent({ connect: { allowH2: false } }));
+const jsforceDispatcher = new Agent({ connect: { allowH2: false } });
 
 type CodedError = {
   code?: string;
@@ -124,7 +123,7 @@ async function startFetchRequest(
       duplex: 'half',
       redirect: 'manual',
       signal: controller.signal,
-      dispatcher: agent,
+      dispatcher: agent ?? jsforceDispatcher,
     };
 
     try {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
-import {fetch, errors, Response, RequestInit, ProxyAgent, Agent} from 'undici';
+import {fetch, errors, Response, RequestInit, ProxyAgent, Agent, Dispatcher} from 'undici';
 import {
   createHttpRequestHandlerStreams,
   executeWithTimeout,
@@ -11,7 +11,11 @@ import { HttpRequest, HttpRequestOptions } from './types';
 import { getLogger } from './util/logger';
 import is from '@sindresorhus/is';
 
-const jsforceDispatcher = new Agent({ connect: { allowH2: false } });
+let jsforceDispatcher: Dispatcher = new Agent({ connect: { allowH2: false } });
+
+export function setDispatcher(dispatcher?: Dispatcher) {
+  jsforceDispatcher = dispatcher ?? new Agent({ connect: { allowH2: false } });
+}
 
 type CodedError = {
   code?: string;

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Duplex, Readable, Writable } from 'stream';
-import {fetch, errors, Response, RequestInit, ProxyAgent, Agent} from 'undici';
+import {fetch, errors, Response, RequestInit, ProxyAgent, Agent, setGlobalDispatcher} from 'undici';
 import {
   createHttpRequestHandlerStreams,
   executeWithTimeout,
@@ -12,7 +12,7 @@ import { getLogger } from './util/logger';
 import is from '@sindresorhus/is';
 
 // undici 8.x defaults to H2, causing crashes on server GOAWAY frames
-const noH2Agent = new Agent({ connect: { allowH2: false } });
+setGlobalDispatcher(new Agent({ connect: { allowH2: false } }));
 
 type CodedError = {
   code?: string;
@@ -43,7 +43,7 @@ async function startFetchRequest(
 ) {
   const logger = getLogger('fetch');
   const { httpProxy, followRedirect } = options;
-  const agent = httpProxy ? new ProxyAgent({ uri: httpProxy, requestTls: { allowH2: false } }) : noH2Agent;
+  const agent = httpProxy ? new ProxyAgent({ uri: httpProxy, requestTls: { allowH2: false } }) : undefined;
   const { url, body, ...rrequest } = request;
   const controller = new AbortController();
 

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -5,23 +5,22 @@ import { HttpRequest } from '../src/types';
 import { Transport } from '../src/transport';
 import assert from 'assert';
 import xml2js from 'xml2js';
-import {MockAgent, setGlobalDispatcher, getGlobalDispatcher, Dispatcher, errors} from 'undici';
+import {MockAgent, errors} from 'undici';
 import { HttpRequestOptions, HttpResponse } from '../src/types/common';
+import { setDispatcher } from '../src/request';
 
 const loginUrl = 'https://heaven-party-2429-dev-ed.scratch.my.salesforce.com';
 
 let mockAgent: MockAgent;
-let originalDispatcher: Dispatcher;
 
 beforeEach(() => {
-  originalDispatcher = getGlobalDispatcher();
   mockAgent = new MockAgent();
   mockAgent.disableNetConnect();
-  setGlobalDispatcher(mockAgent);
+  setDispatcher(mockAgent);
 });
 
 afterEach(async () => {
-  setGlobalDispatcher(originalDispatcher);
+  setDispatcher();
   await mockAgent.close();
 });
 


### PR DESCRIPTION
### Summary

  - undici 8.x defaults to HTTP/2, causing unhandled SocketError crashes when Salesforce servers send GOAWAY frames during any sf command
  - Disable HTTP/2 by setting allowH2: false on the undici dispatcher for both direct and proxied connections

### Fix

  Force HTTP/1.1 by passing allowH2: false to the undici dispatcher, restoring the pre-v3.10.17 behavior where jsforce never used HTTP/2.


Cli issue related: https://github.com/forcedotcom/cli/issues/3622
@W-23797589@