### PR TITLE
W-24010598: always release on a manual workflow run

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -37,6 +37,9 @@ jobs:
           output-file: 'CHANGELOG.md'
           pre-commit: ./scripts/bump-version-file.js
           tag-prefix: ''
+          # On a push, skip the release if there are no semantic commits.
+          # On a manual run (workflow_dispatch), force the release even with no semantic commits.
+          skip-on-empty: ${{ github.event_name == 'push' }}
       - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
         id: packageVersion
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsforce",
-  "version": "3.10.22",
+  "version": "3.10.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsforce",
-      "version": "3.10.22",
+      "version": "3.10.23",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",


### PR DESCRIPTION
Change the create-github-release flow to always release when you manually run the `create-github-release.yml` workflows. This will help us quickly release if we forget a `fix:` or `feat:` conventional commit.

This is similar to what we do in our (Salesforce) shared github-workflows repo, only here we will not use the shared repo 
Example:
1. https://github.com/salesforcecli/plugin-org/blob/main/.github/workflows/create-github-release.yml#L25
2. https://github.com/salesforcecli/github-workflows/blob/main/.github/workflows/create-github-release.yml#L91

[@W-24010598@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-24010598)
