### PR TITLE
fix: export describe-related types

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -181,7 +181,7 @@ export type Field = {
   writeRequiresMasterRead: boolean;
 };
 
-type ActionOverride = {
+export type ActionOverride = {
   formFactor: string;
   isAvailableInTouch: boolean;
   name: string;
@@ -189,7 +189,7 @@ type ActionOverride = {
   url: Optional<string>;
 };
 
-type ChildRelationship = {
+export type ChildRelationship = {
   cascadeDelete: boolean;
   childSObject: string;
   deprecatedAndHidden: boolean;
@@ -200,12 +200,12 @@ type ChildRelationship = {
   restrictedDelete: boolean;
 };
 
-type NamedLayoutInfo = {
+export type NamedLayoutInfo = {
   name: string;
   urls: { [key: string]: string };
 };
 
-type RecordTypeInfo = {
+export type RecordTypeInfo = {
   available: boolean;
   defaultRecordTypeMapping: boolean;
   master: boolean;
@@ -214,12 +214,12 @@ type RecordTypeInfo = {
   urls: { [key: string]: string };
 };
 
-type ScopeInfo = {
+export type ScopeInfo = {
   label: string;
   name: string;
 };
 
-type DescribeGlobalSObjectResult = {
+export type DescribeGlobalSObjectResult = {
   activateable: boolean;
   createable: boolean;
   custom: boolean;


### PR DESCRIPTION
## Summary
- Export 6 types from `src/types/common.ts` that are part of the public `DescribeSObjectResult` shape but were not previously exported: `ActionOverride`, `ChildRelationship`, `NamedLayoutInfo`, `RecordTypeInfo`, `ScopeInfo`, `DescribeGlobalSObjectResult`

## Why
`@oclif/plugin-command-snapshot` v6 upgraded `ts-json-schema-generator` from 1.x to 2.x. The new version only emits exported types as named `$ref` definitions in generated JSON schemas (config: `expose: "export"`). Non-exported types get inlined, which caused the `plugin-schema` `sobject-describe.json` schema to change dramatically — CI flagged it as a breaking change.

Exporting these types restores named `$ref` definitions in the generated schema and benefits any downstream consumer that needs to reference these types directly.

## Test plan
- [x] `npm run build` passes — compiled `.d.ts` files now export the types
- [ ] CI tests should pass — this is additive (exporting previously non-exported types is non-breaking)